### PR TITLE
Fixed creation of invalid Ingress resource

### DIFF
--- a/nexus-repository-manager/templates/ingress.yaml
+++ b/nexus-repository-manager/templates/ingress.yaml
@@ -28,8 +28,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- range .Values.ingress.hosts }}
   rules:
+  {{- range .Values.ingress.hosts }}
     - host: {{ .host }}
       http:
         paths:

--- a/nexus-repository-manager/templates/ingress.yaml
+++ b/nexus-repository-manager/templates/ingress.yaml
@@ -28,14 +28,18 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  {{- range .Values.ingress.hosts }}
   rules:
-    - host: repo.demo
+    - host: {{ .host }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+        {{- range .paths }}
+          - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8081
+        {{- end }}
+  {{- end }}
   {{- range .Values.service.additionalPorts }}
     - host: {{ .host | quote }}
       http:


### PR DESCRIPTION
Currently there is no way to use custom Ingress resources with your own domain. This PR fixes this behavior by implementing correct parsing of the ingress.hosts key from the values.yaml