### PR TITLE
Added default docker ports for the deployment and service

### DIFF
--- a/nexus-repository-manager/templates/deployment.yaml
+++ b/nexus-repository-manager/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
           ports:
             - name: nexus-ui
               containerPort: {{ .Values.nexus.nexusPort }}
+            - name: docker-default
+              containerPort: 5000
           livenessProbe:
             httpGet:
               path: {{ .Values.nexus.livenessProbe.path }}

--- a/nexus-repository-manager/templates/service.yaml
+++ b/nexus-repository-manager/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
     - port: 8081
       protocol: TCP
       name: nexus-ui
+    - port: 5000
+      protocol: TCP
+      name: docker-default
   selector:
     {{- include "nexus.selectorLabels" . | nindent 4 }}
     {{- if .Values.nexus.extraSelectorLabels }}


### PR DESCRIPTION
The docker ingress resource was missing the appropriate ports in the deployment and service. This commit adds them.