### PR TITLE
Fix Markdown table rendering bug

### DIFF
--- a/nexus-repository-manager/README.md
+++ b/nexus-repository-manager/README.md
@@ -98,7 +98,6 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.docker.registries[0].host`           | Host for the docker registry        | `cluster.local`                         |
 | `nexus.docker.registries[0].port`           | Port for the docker registry        | `5000`                                  |
 | `nexus.docker.registries[0].secretName`     | TLS Secret Name for the ingress     | `registrySecret`                        |
-
 | `nexus.env`                                 | Nexus environment variables         | `[{install4jAddVmParams: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}]` |
 | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |


### PR DESCRIPTION
The empty line in the table was causing the Markdown to not render correctly and making it hard to read some settings. This should fix it.