### PR TITLE
Fixes sonatype/helm3-charts#21

### DIFF
--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.1.0
+version: 29.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.29.0

--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.2.0
+version: 29.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.29.0

--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -115,6 +115,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
+| `nexus.properties.override`                 | Set to true to override default nexus.properties | `false`                    |
+| `nexus.properties.data`                 | A map of custom nexus properties if `override` is set to true | `nexus.scripts.allowCreation: true`            |
 | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{kubernetes.io/ingress.class: nginx}`                          |
 | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |

--- a/charts/nexus-repository-manager/templates/configmap-properties.yaml
+++ b/charts/nexus-repository-manager/templates/configmap-properties.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.nexus.properties.override -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nexus.name" . }}-properties
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+    {{- if .Values.nexus.extraLabels }}
+      {{- with .Values.nexus.extraLabels }}
+        {{ toYaml . | indent 4 }}
+      {{- end }}
+    {{- end }}
+data:
+  nexus.properties: |
+    {{- range $k, $v := .Values.nexus.properties.data }}
+    {{ $k }}={{ $v }}
+    {{- end }}
+{{- end }}

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -109,6 +109,11 @@ spec:
             - mountPath: {{ .Values.config.mountPath }}
               name: {{ template "nexus.name" . }}-conf
             {{- end }}
+            {{- if .Values.nexus.properties.override }}
+            - mountPath: /nexus-data/etc/nexus.properties
+              name: {{ template "nexus.name" . }}-properties
+              subPath: nexus.properties
+            {{- end }}
             {{- if .Values.secret.enabled }}
             - mountPath: {{ .Values.secret.mountPath }}
               name: {{ template "nexus.name" . }}-secret
@@ -136,6 +141,14 @@ spec:
         - name: {{ template "nexus.name" . }}-conf
           configMap:
             name: {{ template "nexus.name" . }}-conf
+        {{- end }}
+        {{- if .Values.nexus.properties.override }}
+        - name: {{ template "nexus.name" . }}-properties
+          configMap:
+            name: {{ template "nexus.name" . }}-properties
+            items:
+            - key: nexus.properties
+              path: nexus.properties
         {{- end }}
         {{- if .Values.secret.enabled }}
         - name: {{ template "nexus.name" . }}-secret

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -25,6 +25,8 @@ nexus:
     override: false
     data:
       nexus.scripts.allowCreation: true
+      # See this article for ldap configuratioon options https://support.sonatype.com/hc/en-us/articles/216597138-Setting-Advanced-LDAP-Connection-Properties-in-Nexus-Repository-Manager
+      #nexus.ldap.env.java.naming.security.authentication: simple
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: default-pool
   resources: {}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -21,6 +21,10 @@ nexus:
       value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "true"
+  properties:
+    override: false
+    data:
+      nexus.scripts.allowCreation: true
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: default-pool
   resources: {}


### PR DESCRIPTION
Proof that it works :) 

![image](https://user-images.githubusercontent.com/2006610/101770696-1f309280-3ae9-11eb-924c-8da6d8f60a57.png)

Also, I've used a map for configmap in case someone keeps a separate `values-sercrets.yaml` file, so secret values for nexus properties can be merged with non-secret ones. And the only thing that may be secret there (I think) is ldap credentials:

![image](https://user-images.githubusercontent.com/2006610/101770944-80f0fc80-3ae9-11eb-8229-e0f0eff289f4.png)

And seems like they can be set in nexus.properties according to this [article](https://support.sonatype.com/hc/en-us/articles/216597138-Setting-Advanced-LDAP-Connection-Properties-in-Nexus-Repository-Manager) but I haven't tested myself

And one more note, I could not find how current configmap setup is used, so created a separate one to avoid potential breaking changes. The same approach could be used later for other configuration files like `nexus.vmoptions` if anyone needs it.