### PR TITLE
republish  29.1.0

### DIFF
--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.0.2
+version: 29.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.29.0


### PR DESCRIPTION
Issue #39 was cause by a PR that created the chart version 29.1.0 which I missed. I deleted the package here on GH thinking it would get removed. this is about when I noticed our index file wasn't being updated by the chart releaser.

Releasing charts...
Using config file:  /home/runner/work/helm3-charts/helm3-charts/cr.yaml
Updating charts repo index...
Using config file:  /home/runner/work/helm3-charts/helm3-charts/cr.yaml
Using existing index at .cr-index/index.yaml
Found nexus-repository-manager-29.0.2.tgz
Extracting chart metadata from .cr-release-packages/nexus-repository-manager-29.0.2.tgz
Calculating Hash for .cr-release-packages/nexus-repository-manager-29.0.2.tgz
Updating index .cr-index/index.yaml

look for another PR to fix the index