### PR TITLE
Add load balancer IP to Repository Manager

### DIFF
--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `service.labels`                            | Service labels                   | `nil`                                      |
 | `service.annotations`                       | Service annotations              | `nil`                                      |
 | `service.type`                              | Service Type                     | `ClusterIP`                                |
+| `service.loadBalancerIP`                    | Load balancer IP for service     | `nil`                                      |
 | `route.enabled`         | Set to true to create route for additional service | `false` |
 | `route.name`            | Name of route                                      | `docker` |
 | `route.portName`        | Target port name of service                        | `docker` |

--- a/charts/nexus-repository-manager/templates/service.yaml
+++ b/charts/nexus-repository-manager/templates/service.yaml
@@ -17,6 +17,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{ if $.Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ $.Values.service.loadBalancerIP }}
+  {{ end }}
   ports:
     - port: {{ .Values.nexus.nexusPort }}
       protocol: TCP
@@ -49,6 +52,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ $.Values.service.type }}
+  {{ if $.Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ $.Values.service.loadBalancerIP }}
+  {{ end }}
   ports:
     - port: {{ $registry.port }}
       protocol: TCP

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -123,6 +123,7 @@ service:
   labels: {}
   annotations: {}
   serviceType: ClusterIP
+  loadBalancerIP:
 
 
 route:


### PR DESCRIPTION
Chart currently doesn't have a way to set the IP when the service mode is `LoadBalancer`, this PR introduces that functionality.