### PR TITLE
upgrade to IQ 1.105.0

### DIFF
--- a/charts/nexus-iq/Chart.yaml
+++ b/charts/nexus-iq/Chart.yaml
@@ -3,10 +3,10 @@ name: nexus-iq-server
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 103.0.1
+version: 105.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.103.0
+appVersion: 1.105.0
 
 description: Sonatype Nexus IQ Server continuously monitors your entire software supply chain
 

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   # Sonatype Official Public Image
   repository: sonatype/nexus-iq-server
-  tag: 1.103.0
+  tag: 1.105.0
   pullPolicy: IfNotPresent
   
 iq:


### PR DESCRIPTION
Upgrading looks pretty easy now. This is the IQ 105 release for helm3 charts.

JIRA: https://issues.sonatype.org/browse/INT-4387
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-4387-upgrade-iq-105/