### PR TITLE
feat: Convert docker registries to connectors

### DIFF
--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.2.0
+version: 30.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.29.2

--- a/charts/nexus-repository-manager/templates/_helpers.tpl
+++ b/charts/nexus-repository-manager/templates/_helpers.tpl
@@ -43,12 +43,26 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "nexus.labelsExtra" -}}
+{{- include "nexus.labels" . }}
+{{ with .Values.nexus.extraLabels }}
+{{- toYaml . }}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Selector labels
 */}}
 {{- define "nexus.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "nexus.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "nexus.selectorLabelsExtra" -}}
+{{- include "nexus.selectorLabels" . }}
+{{ with .Values.nexus.extraSelectorLabels }}
+{{- toYaml . }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -2,13 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nexus.fullname" . }}
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-  {{- if .Values.nexus.extraLabels }}
-    {{- with .Values.nexus.extraLabels }}
-      {{ toYaml . | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels: {{ include "nexus.labelsExtra" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}
@@ -18,13 +12,7 @@ spec:
   strategy:
     type: {{ .Values.deploymentStrategy }}
   selector:
-    matchLabels:
-      {{- include "nexus.selectorLabels" . | nindent 6 }}
-      {{- if .Values.nexus.extraSelectorLabels }}
-        {{- with .Values.nexus.extraSelectorLabels }}
-          {{ toYaml . | indent 6 }}
-        {{- end }}
-      {{- end }}      
+    matchLabels: {{- include "nexus.selectorLabelsExtra" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -37,51 +25,40 @@ spec:
     spec:
       serviceAccountName: {{ include "nexus.serviceAccountName" . }}
       {{- if .Values.deployment.initContainers }}
-      initContainers:
-{{ toYaml .Values.deployment.initContainers | indent 6 }}
+      initContainers: {{- toYaml .Values.deployment.initContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.nexus.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nexus.nodeSelector | indent 8 }}
+      nodeSelector: {{- toYaml .Values.nexus.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.nexus.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.nexus.hostAliases | indent 8 }}
+      hostAliases: {{- toYaml .Values.nexus.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if .Values.nexus.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- with .Values.nexus.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-
           lifecycle:
           {{- if .Values.deployment.postStart.command }}
             postStart:
               exec:
                 command: {{ .Values.deployment.postStart.command }}
           {{- end }}
-          env:
-{{ toYaml .Values.nexus.env | indent 12 }}
-          envFrom:
-{{ toYaml .Values.nexus.envFrom | indent 12 }}
-          resources:
-{{ toYaml .Values.nexus.resources | indent 12 }}
+          env: {{- toYaml .Values.nexus.env | nindent 12 }}
+          envFrom: {{- toYaml .Values.nexus.envFrom | nindent 12 }}
+          resources: {{- toYaml .Values.nexus.resources | nindent 12 }}
           ports:
-            - name: nexus-ui
+            - name: http-nexus-ui
               containerPort: {{ .Values.nexus.nexusPort }}
-            {{- if .Values.nexus.docker.enabled }}
-            {{- range .Values.nexus.docker.registries }}
-            - name: docker-{{ .port }}
+            {{- range .Values.ingress.connectors }}
+            - name: http-{{ .port }}
               containerPort: {{ .port }}
-            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:
@@ -121,14 +98,13 @@ spec:
               readOnly: {{ .Values.secret.readOnly }}
             {{- end }}
             {{- if .Values.deployment.additionalVolumeMounts}}
-{{ toYaml .Values.deployment.additionalVolumeMounts | indent 12 }}
+            {{- toYaml .Values.deployment.additionalVolumeMounts | indent 12 }}
             {{- end }}
         {{- if .Values.deployment.additionalContainers }}
-{{ toYaml .Values.deployment.additionalContainers | indent 8 }}
+        {{- toYaml .Values.deployment.additionalContainers | indent 8 }}
         {{- end }}
       {{- if .Values.nexus.securityContext }}
-      securityContext:
-{{ toYaml .Values.nexus.securityContext | indent 8 }}
+      securityContext: {{- toYaml .Values.nexus.securityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: {{ template "nexus.name" . }}-data
@@ -157,9 +133,6 @@ spec:
             secretName: {{ template "nexus.name" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
-{{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
+        {{- toYaml .Values.deployment.additionalVolumes | indent 8 }}
         {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -1,73 +1,74 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nexus.fullname" . -}}
-{{- $svcPort := .Values.nexus.nexusPort -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- $labelsExtra := include "nexus.labelsExtra" . -}}
+---
+{{- if (semverCompare "<=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    {{- include "nexus.labels" . | nindent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ $labelsExtra | nindent 4 }}
+  annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.ingress.ingressClass }}
+  ingressClassName: {{ .Values.ingress.ingressClass }}
+  {{- end }}
+  {{- if .Values.ingress.tls.secretName }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-      - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    - hosts: {{- toYaml .Values.ingress.hosts | nindent 8 }}
+      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.hostRepo }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          - path: {{ .Values.ingress.hostPath }}
+          - path: {{ $.Values.ingress.path }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
+            {{- end }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8081
-
-{{ if .Values.nexus.docker.enabled }}
-{{ range $registry := .Values.nexus.docker.registries }}
+    {{- end }}
+...
+{{- range $connector := .Values.ingress.connectors }}
 ---
+{{- if (semverCompare "<=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
-  labels:
-    {{- include "nexus.labels" $ | nindent 4 }}
-    {{- if $.Values.nexus.extraLabels }}
-      {{- with $.Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
-  {{- with $.Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  name: {{ $fullName | trunc 49 }}-docker-{{ $connector.port }}
+  labels: {{ $labelsExtra | nindent 4 }}
+  annotations: {{- toYaml $.Values.ingress.annotations | nindent 4 }}
 spec:
+  {{- if and (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) (or $connector.ingressClass $.Values.ingress.ingressClass) }}
+  ingressClassName: {{ $connector.ingressClass | default $.Values.ingress.ingressClass }}
+  {{- end }}
+  {{- if $connector.tls.secretName }}
   tls:
-    - hosts:
-      - {{ $registry.host | quote }}
-      secretName: {{ $registry.secretName }}
+    - hosts: {{ toYaml $connector.hosts | nindent 8 }}
+      secretName: {{ $connector.tls.secretName }}
+  {{- end }}
   rules:
-    - host: {{ $registry.host }}
+    {{- range $host := $connector.hosts }}
+    - host: {{ $host }}
       http:
         paths:
           - path: /
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
+            {{- end }}
             backend:
-              serviceName: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
-              servicePort: {{ $registry.port }}
+              serviceName: {{ $fullName | trunc 49 }}-connector-{{ $connector.port }}
+              servicePort: {{ $connector.port }}
     {{- end }}
-{{- end }}
+...
+{{- end -}}
 {{- end }}

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -44,7 +44,7 @@ apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName | trunc 49 }}-docker-{{ $connector.port }}
+  name: {{ $fullName | trunc 47 }}-connector-{{ $connector.port }}
   labels: {{ $labelsExtra | nindent 4 }}
   annotations: {{- toYaml $.Values.ingress.annotations | nindent 4 }}
 spec:

--- a/charts/nexus-repository-manager/templates/pvc.yaml
+++ b/charts/nexus-repository-manager/templates/pvc.yaml
@@ -3,13 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nexus.fullname" . }}-data
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{- include "nexus.labelsExtra" . | nindent 4 }}
 {{- if .Values.persistence.annotations }}
   annotations:
 {{ toYaml .Values.persistence.annotations | indent 4 }}

--- a/charts/nexus-repository-manager/templates/service.yaml
+++ b/charts/nexus-repository-manager/templates/service.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.service.enabled -}}
+{{- $labelsExtra := include "nexus.labelsExtra" . -}}
+{{- $selectorLabelsExtra := include "nexus.selectorLabelsExtra" . -}}
 ---
 apiVersion: v1
 kind: Service
@@ -8,59 +10,33 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
-  labels:
-    {{- include "nexus.labels" . | nindent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{- $labelsExtra | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.nexus.nexusPort }}
       protocol: TCP
-      name: nexus-ui
-  selector:
-    {{- include "nexus.selectorLabels" . | nindent 4 }}
-    {{- if .Values.nexus.extraSelectorLabels }}
-      {{- with .Values.nexus.extraSelectorLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
-
-{{- if .Values.nexus.docker.enabled }}
-{{- range $registry := .Values.nexus.docker.registries }}
+      name: http-nexus-ui
+  selector: {{- $selectorLabelsExtra | nindent 4 }}
+...
+{{- range $connector := .Values.ingress.connectors }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "nexus.fullname" $ | trunc 49 }}-docker-{{ $registry.port }}
+  name: {{ include "nexus.fullname" $ | trunc 49 }}-connector-{{ $connector.port }}
 {{- if $.Values.service.annotations }}
   annotations:
 {{ toYaml $.Values.service.annotations | indent 4 }}
 {{- end }}
-  labels:
-    {{- include "nexus.labels" $ | nindent 4 }}
-    {{- if $.Values.nexus.extraLabels }}
-      {{- with $.Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{- $labelsExtra | nindent 4 }}
 spec:
   type: {{ $.Values.service.type }}
   ports:
-    - port: {{ $registry.port }}
+    - port: {{ $connector.port }}
       protocol: TCP
-      name: docker-{{ $registry.port }}
-  selector:
-    {{- include "nexus.selectorLabels" $ | nindent 4 }}
-    {{- if $.Values.nexus.extraSelectorLabels }}
-      {{- with $.Values.nexus.extraSelectorLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
-{{- end }}
-
+      name: http-{{ $connector.port }}
+  selector: {{- $selectorLabelsExtra | nindent 4 }}
+...
 {{- end }}
 {{- end }}

--- a/charts/nexus-repository-manager/templates/serviceaccount.yaml
+++ b/charts/nexus-repository-manager/templates/serviceaccount.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nexus.serviceAccountName" . }}
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-  {{- if .Values.nexus.extraLabels }}
-    {{- with .Values.nexus.extraLabels }}
-      {{ toYaml . | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels: {{- include "nexus.labelsExtra" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -1,6 +1,9 @@
 statefulset:
   # This is not supported
   enabled: false
+
+securityContext: {}
+
 # By default deploymentStrategy is set to rollingUpdate with maxSurge of 25% and maxUnavailable of 25% . you can change type to `Recreate` or can uncomment `rollingUpdate` specification and adjust them to your usage.
 deploymentStrategy: Recreate
 image:
@@ -10,12 +13,9 @@ image:
   pullPolicy: IfNotPresent
 
 nexus:
-  docker:
-    enabled: false
-    registries: []
-    #  - host: chart.local
-    #    port: 5000
-    #    secretName: registrySecret
+  extraLabels: {}
+  extraSelectorLabels: []
+  envFrom: []
   env:
     - name: install4jAddVmParams
       value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
@@ -30,17 +30,18 @@ nexus:
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: default-pool
   resources: {}
-    # requests:
-      ## Based on https://support.sonatype.com/hc/en-us/articles/115006448847#mem
-      ## and https://twitter.com/analytically/status/894592422382063616:
-      ##   Xms == Xmx
-      ##   Xmx <= 4G
-      ##   MaxDirectMemory >= 2G
-      ##   Xmx + MaxDirectMemory <= RAM * 2/3 (hence the request for 4800Mi)
-      ##   MaxRAMFraction=1 is not being set as it would allow the heap
-      ##     to use all the available memory.
-      # cpu: 250m
-      # memory: 4800Mi
+  ## Based on https://support.sonatype.com/hc/en-us/articles/115006448847#mem
+  ## and https://twitter.com/analytically/status/894592422382063616:
+  ##   Xms == Xmx
+  ##   Xmx <= 4G
+  ##   MaxDirectMemory >= 2G
+  ##   Xmx + MaxDirectMemory <= RAM * 2/3 (hence the request for 4800Mi)
+  ##   MaxRAMFraction=1 is not being set as it would allow the heap
+  ##     to use all the available memory.
+  # requests:
+  #   cpu: 250m
+  #   memory: 4800Mi
+
   # The ports should only be changed if the nexus image uses a different port
   nexusPort: 8081
 
@@ -76,15 +77,16 @@ deployment:
   annotations: {}
   # # Add init containers. e.g. to be used to give specific permissions for nexus-data.
   # # Add your own init container or uncomment and modify the given example.
-  initContainers:
-  # - name: fmp-volume-permission
-    # image: busybox
-    # imagePullPolicy: IfNotPresent
-    # command: ['chown','-R', '200', '/nexus-data']
-    # volumeMounts:
-      # - name: nexus-data
-        # mountPath: /nexus-data
-  # # Uncomment and modify this to run a command after starting the nexus container.
+  initContainers: []
+#   - name: fmp-volume-permission
+#     image: busybox
+#     imagePullPolicy: IfNotPresent
+#     command: ['chown','-R', '200', '/nexus-data']
+#     volumeMounts:
+#      - name: nexus-data
+#        mountPath: /nexus-data
+
+##  Uncomment and modify this to run a command after starting the nexus container.
   postStart:
     command:    # '["/bin/sh", "-c", "ls"]'
   preStart:
@@ -96,19 +98,30 @@ deployment:
 
 
 ingress:
-  enabled: false
-  annotations: {kubernetes.io/ingress.class: nginx}
+  enabled: true
+  annotations: {}
+    # It's recommended to set "ingressClass" directly rather than using
+    # the annotations in newer versions of Kubernetes.
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hostPath: /
-  hostRepo: repo.demo
-  tls: []
-    # - secretName: nexus-local-tls
-    #   hosts:
-    #     - nexus.local
-    #     - nexus-docker.local
-    #     - nexus-docker-hosted.local
-
+  path: /
+  ingressClass: ""
+  hosts: []
+    # - repo.demo
+  tls: {}
+    # secretName: nexus-local-tls
+  connectors: []
+    # - hosts:
+    #     - docker.repo.demo
+    #   port: 5000
+    #   tls:
+    #     secretName: nexus-local-tls
+    # - hosts:
+    #     - docker-push.repo.demo
+    #   port: 5001
+    #   ingressClass: ""
+    #   tls:
+    #     secretName: nexus-local-tls
 
 service:
   name: nexus3
@@ -117,7 +130,7 @@ service:
   annotations: {}
   serviceType: ClusterIP
 
-
+#### OpenShift
 route:
   enabled: false
   name: docker
@@ -126,6 +139,7 @@ route:
   annotations:
   # path: /docker
 
+#### OpenShift
 nexusProxyRoute:
   enabled: false
   labels:
@@ -153,9 +167,9 @@ persistence:
 tolerations: []
 
 # # Enable configmap and add data in configmap	
-config:	
-  enabled: false	
-  mountPath: /sonatype-nexus-conf	
+config:
+  enabled: false
+  mountPath: /sonatype-nexus-conf
   data: []
 
 # # To use an additional secret, set enable to true and add data


### PR DESCRIPTION
Went on a little bit of a mission with this PR, but ultimately there were two issues encountered when trying to use the chart and these are my solutions.

Firstly the chart had a notion of using docker registries and having ingress to them, that's great but inside nexus they're called connectors, and there's nothing to say they need to be locked down to docker, simply that they're http. My use case was docker and nuget, as an example.

Secondly since I'm using Istio ingress the lack of good configuration of the pathType, and being able to set the ingressClass outside of an annotation was causing me some issues so I modernised the ingress manifests to the latest (but backwards compatible) versions with some sensible pathType's of `Prefix` set.

Happy to make any changes desired to make this mergeable since I acknowledge I've changed a fair bit of the interface for users of the chart by tweaking the ingress object.