### PR TITLE
Support adding additional hosts in ingress

### DIFF
--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -36,6 +36,17 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8081
+    {{- if .Values.ingress.additionalHosts }}
+    {{ range $host := .Values.ingress.additionalHosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.hostPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8081
+    {{- end }}
+    {{- end }}
 
 {{ if .Values.nexus.docker.enabled }}
 {{ range $registry := .Values.nexus.docker.registries }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -115,6 +115,9 @@ ingress:
     #     - nexus.local
     #     - nexus-docker.local
     #     - nexus-docker-hosted.local
+  #additionalHosts:
+  #  - internal.example.com
+  #  - external.example.com
 
 
 service:


### PR DESCRIPTION
In our deployment, the cluster run behind our firewall so we can access it via an internal domain.
We also made port-forwading on a specific external domain, so our team can access it while work from home. This requires to have more rules in the ingress, so I made this PR.

Feel free to correct me, if there's any mistakes.

_Regards,_
