### PR TITLE
Initial contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. Before
+we can accept any pull request, all contributors must first sign the Sonatype Contributor
+License Agreement (CLA) at:https://sonatypecla.herokuapp.com/sign-cla
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 
 Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help get you started in the right direction.
 
-* Hit us up on our Slack channel #react-components.
+* Hit us up on our Slack channel #integrations.
 * Please fill out an issue (Jira INT project) for your PR so that we have traceability as to what you are trying to fix,
   versus how you fixed it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,94 +1,51 @@
-# Contributing
+<!--
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. Before
-we can accept any pull request, all contributors must first sign the Sonatype Contributor
-License Agreement (CLA) at:https://sonatypecla.herokuapp.com/sign-cla
+    Copyright (c) 2019-present Sonatype, Inc.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+-->
 
-## Pull Request Process
+# How to be a contributor to this project
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
-   build.
-2. Update the README.md with details of changes to the interface, this includes new environment 
-   variables, exposed ports, useful file locations and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
-   do not have permission to do that, you may request the second reviewer to merge it for you.
+## Talk to a human first
 
-## Code of Conduct
+### For Sonatypers
 
-### Our Pledge
+Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help get you started in the right direction.
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+* Hit us up on our Slack channel #react-components.
+* Please fill out an issue (Jira INT project) for your PR so that we have traceability as to what you are trying to fix,
+  versus how you fixed it.
 
-### Our Standards
+### For Non-Sonatypers
 
-Examples of behavior that contributes to creating a positive environment
-include:
+* Come hang out with us at our [gitter channel](https://gitter.im/sonatype/nexus-developers) so we can try to understand the problem you are trying to solve.
+* Sign the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+## Submitting a PR
 
-Examples of unacceptable behavior by participants include:
+* Try to fix one thing per pull request! Many people work on this code, so the more focused your changes are, the less
+  of a headache other people will have when they merge their work in.
+* Ensure your Pull Request passes tests either locally or via Jenkins (it will run automatically on your PR)
+* If you're stuck, ask our [gitter channel](https://gitter.im/sonatype/nexus-developers) or #react-components in Slack! There are a number of
+  experienced programmers who are happy to help with learning and troubleshooting.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+### PR commenting protocol
 
-### Our Responsibilities
+Here are the general rules to follow when commenting on PRs for this repo:
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-### Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-### Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+* When leaving comments on a PR, leave them all as individual comments as opposed to "Starting a Review".  This is
+  because some people prefer to receive each comment as a separate email.
+* When responding to a comment, always blockquote what you are responding to (even if it is the entire previous
+  comment).  This allows the emails to have the necessary conversation context that they otherwise lack
+* When you as the PR author make a change in response to a comment, respond to that comment and include the commit hash
+  where you made the fix.  Do not resolve the thread
+* The originator of a thread should be the person to mark that thread resolved, typically after reviewing the commit
+  referenced in the response comment from the PR author and finding it acceptable.
+* Unless stated otherwise by the commenter, or clearly not meant to be responded to, all comments on a PR are expected
+  to be addressed before it is merged. Sometimes it is alright for a reviewer to approve the PR before all of their
+  comments are addressed, but generally only when those comments are expected to be easily addressable without further
+  discussion (for example simple formatting issues).  Even in this case though, the comments should still be addressed
+  post-approval

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,6 @@ Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help g
 
 Here are the general rules to follow when commenting on PRs for this repo:
 
-* When leaving comments on a PR, leave them all as individual comments as opposed to "Starting a Review".  This is
-  because some people prefer to receive each comment as a separate email.
 * When responding to a comment, always blockquote what you are responding to (even if it is the entire previous
   comment).  This allows the emails to have the necessary conversation context that they otherwise lack
 * When you as the PR author make a change in response to a comment, respond to that comment and include the commit hash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,6 @@ Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help g
 
 Here are the general rules to follow when commenting on PRs for this repo:
 
-* When responding to a comment, always blockquote what you are responding to (even if it is the entire previous
-  comment).  This allows the emails to have the necessary conversation context that they otherwise lack
-* When you as the PR author make a change in response to a comment, respond to that comment and include the commit hash
-  where you made the fix.  Do not resolve the thread
-* The originator of a thread should be the person to mark that thread resolved, typically after reviewing the commit
-  referenced in the response comment from the PR author and finding it acceptable.
 * Unless stated otherwise by the commenter, or clearly not meant to be responded to, all comments on a PR are expected
   to be addressed before it is merged. Sometimes it is alright for a reviewer to approve the PR before all of their
   comments are addressed, but generally only when those comments are expected to be easily addressable without further

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help g
 
 ## Submitting a PR
 
-* Add the `@sonatype/integrations` group as a reviewer on the PR
+* For Sonatype submitters, add the `@sonatype/integrations` group as a reviewer on the PR
 * Try to fix one thing per pull request! Many people work on this code, so the more focused your changes are, the less
   of a headache other people will have when they merge their work in.
 * Ensure your Pull Request passes tests either locally or via Jenkins (it will run automatically on your PR)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,11 @@ Looking to dive in? FANTASTIC! Reach out to one of our experts and we can help g
 
 ## Submitting a PR
 
+* Add the `@sonatype/integrations` group as a reviewer on the PR
 * Try to fix one thing per pull request! Many people work on this code, so the more focused your changes are, the less
   of a headache other people will have when they merge their work in.
 * Ensure your Pull Request passes tests either locally or via Jenkins (it will run automatically on your PR)
-* If you're stuck, ask our [gitter channel](https://gitter.im/sonatype/nexus-developers) or #react-components in Slack! There are a number of
+* If you're stuck, ask our [gitter channel](https://gitter.im/sonatype/nexus-developers) or #integrations in Slack! There are a number of
   experienced programmers who are happy to help with learning and troubleshooting.
 
 ### PR commenting protocol

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See docs/index.md which is also https://sonatype.github.io/helm3-charts/
 See the [contributing document](./CONTRIBUTING.md) for details.
 
 For Sonatypers, note that external contributors must sign the CLA and
-which the Dev-Ex team must verify prior to accepting any PR.
+the Dev-Ex team must verify this prior to accepting any PR.
 
 ### Updating Charts
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The current releases have been tested on minikube v1.12.3 running k8s v1.18.3
 
 See docs/index.md which is also https://sonatype.github.io/helm3-charts/
 
+### Contributing
+
+See the [contributing document](./CONTRIBUTING.md) for details.
+
+For Sonatypers, note that external contributors must sign the CLA and
+which the Dev-Ex team must verify prior to accepting any PR.
+
 ### Updating Charts
 
 Charts for Nexus IQ and for NXRM can be updated in `charts/` directories.


### PR DESCRIPTION
Attempt to define an initial contributors guide. There do not appear to be many corporate guidelines beyond ensuring that all contributors must sign the CLA https://sonatypecla.herokuapp.com/sign-cla and that we have a license defined (already in place).

Jira: https://issues.sonatype.org/browse/INT-4185