### PR TITLE
Fix imagePullSecrets fuckup

### DIFF
--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.1.0
+version: 30.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.30.1

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       {{- if .Values.nexus.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+{{- toYaml .Values.nexus.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -43,7 +43,7 @@ nexus:
       # memory: 4800Mi
   # The ports should only be changed if the nexus image uses a different port
   nexusPort: 8081
-
+  imagePullSecrets: []
   securityContext:
     fsGroup: 2000
   podAnnotations: {}
@@ -67,7 +67,6 @@ nexus:
   #   - "www.example.com"
 
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
If someone submits something, it's best if they actually test what they submitted.
This one is obviously not tested at all (not even `helm template .`), because it fills the deployment with gibrish (a complete copy of values.yaml to be precise)

A simple solution to prevent this from hapening in the future, is simply adding CI to run the chart. Though if this is supposed to be professional software, some unittests also might be relevant.