### PR TITLE
fix imagePullSecrets

### DIFF
--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       hostAliases:
 {{ toYaml .Values.nexus.hostAliases | indent 8 }}
       {{- end }}
-      {{- if .Values.nexus.imagePullSecrets }}
+      {{- with .Values.nexus.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -65,9 +65,8 @@ nexus:
   #   hostnames:
   #   - "example.com"
   #   - "www.example.com"
+  imagePullSecrets: []
 
-
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
indent in values.yaml

change `if` to `with` in templates/deployment.yaml


fix below error message
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.imagePullSecrets): invalid type for io.k8s.api.core.v1.PodSpec.imagePullSecrets: got "map", expected "array"
```