### PR TITLE
Added log volume and logging for IQ 113

### DIFF
--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           volumeMounts:
             - mountPath: /sonatype-work
               name: nxiq-pv-data
+            - mountPath: /var/log/nexus-iq-server
+              name: nxiq-pv-log
             - mountPath: /etc/nexus-iq-server
               name: config-volume
   {{- if and (.Values.iq.secretName) (.Values.iq.secretMountName) }}
@@ -71,6 +73,9 @@ spec:
         - name: nxiq-pv-data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" (include "iqserver.fullname" .) "data") }}
+        - name: nxiq-pv-log
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" (include "iqserver.fullname" .) "log") }}
         - name: config-volume
           configMap:
             name: {{ template "iqserver.fullname" . }}-conf

--- a/charts/nexus-iq/templates/persistentVolume.yaml
+++ b/charts/nexus-iq/templates/persistentVolume.yaml
@@ -24,4 +24,30 @@ spec:
     pdName: {{ .Values.persistence.pdName }}
     fsType: {{ .Values.persistence.fsType }}
 {{- end }}
+{{- if .Values.persistence.logpdName -}}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.persistence.logpdName }}
+  labels:
+{{ include "iqserver.labels" . | indent 4 }}
+    {{- if .Values.iq.extraLabels }}
+      {{- with .Values.iq.extraLabels }}
+        {{ toYaml . | indent 4 }}
+      {{- end }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  capacity:
+    storage: {{ .Values.persistence.storageSize }}
+  persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ template "iqserver.fullname" . }}-log
+  gcePersistentDisk:
+    pdName: {{ .Values.persistence.logpdName }}
+    fsType: {{ .Values.persistence.fsType }}
+{{- end }}
 {{- end }}

--- a/charts/nexus-iq/templates/persistentVolumeClaim.yaml
+++ b/charts/nexus-iq/templates/persistentVolumeClaim.yaml
@@ -27,4 +27,33 @@ spec:
   storageClassName: "{{ .Values.persistence.storageClass }}"
 {{- end }}
 {{- end }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "iqserver.fullname" . }}-log
+  labels:
+{{ include "iqserver.labels" . | indent 4 }}
+    {{- if .Values.iq.extraLabels }}
+      {{- with .Values.iq.extraLabels }}
+        {{ toYaml . | indent 4 }}
+      {{- end }}
+    {{- end }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storageSize | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -125,9 +125,12 @@ persistence:
   # volumeConfiguration:
   #   hostPath:
   #     path: /data/nxiq/
-  # If PersistentDisk already exists you can create a PV for it by including the 2 following keypairs.
+  # If you want to use existing PersistentDisk with data, you can create a PV for it by uncommenting the following lines. (Currently supports GCE PD only)
   # pdName: nexus-data-disk
   # fsType: ext4
+  # Uncomment below 2 lines, if you want to use an existing GCE PersistentDisk for IQ Logs.
+  # logpdName: nexus-log-disk
+  # logfsType: ext4
 
 # configYaml is the full text of the config.yml file that will be passed to IQ Server
 configYaml:
@@ -144,17 +147,20 @@ configYaml:
     requestLog: 
       appenders:
         #All appenders set to console
-        - type: console    
+        - type: file
+          currentLogFilename: /var/log/nexus-iq-server/request.log    
           # Do not display log statements below this threshold to stdout.
-          threshold: INFO
+          # threshold: INFO
           logFormat: "%clientHost %l %user [%date] \"%requestURL\" %statusCode %bytesSent %elapsedTime \"%header{User-Agent}\""
+          archivedLogFilenamePattern: /var/log/nexus-iq-server/request-%d.log.gz
+          archivedFileCount: 50
   
   createSampleData: true
 
   logging:
 
     # The default level of all loggers. Can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL.
-    level: ERROR
+    level: DEBUG
 
     # Logger-specific settings.
     loggers:
@@ -168,10 +174,12 @@ configYaml:
       "com.sonatype.insight.audit":
         appenders:
           #All appenders set to console
-          - type: console
-    
+          - type: file
+            currentLogFilename: /var/log/nexus-iq-server/audit.log    
             # Do not display log statements below this threshold to stdout.
-            threshold: INFO
+            # threshold: INFO
+            archivedLogFilenamePattern: /var/log/nexus-iq-server/audit-%d.log.gz
+            archivedFileCount: 50
 
       "com.sonatype.insight.policy.violation":
         appenders:
@@ -189,3 +197,16 @@ configYaml:
         threshold: INFO
       
         logFormat: "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
+
+      - type: file
+    
+        # Do not display log statements below this threshold to stdout.
+        threshold: ALL
+      
+        logFormat: "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
+        # The file to which current statements will be logged.
+        currentLogFilename: /var/log/nexus-iq-server/clm-server.log
+        archivedLogFilenamePattern: /var/log/nexus-iq-server/clm-server-%d.log.gz
+        archivedFileCount: 50
+
+


### PR DESCRIPTION
IQ 113 Docker Image have introduced start.sh script that stores stderr to /var/log/nexus-iq-server and adds the volume.
Added PVC / PV for log volume in Helm chart, to fix the below error during helm deployment.

`./start.sh: line 1: /var/log/nexus-iq-server/stderr.log: Permission denied`

Also enabled IQ loggers to use the log files in log volume