### PR TITLE
fix: use the right jvm params env var: INSTALL4J_ADD_VM_PARAMS

### DIFF
--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -93,7 +93,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.docker.registries[0].host`           | Host for the docker registry        | `cluster.local`                         |
 | `nexus.docker.registries[0].port`           | Port for the docker registry        | `5000`                                  |
 | `nexus.docker.registries[0].secretName`     | TLS Secret Name for the ingress     | `registrySecret`                        |
-| `nexus.env`                                 | Nexus environment variables         | `[{install4jAddVmParams: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}]` |
+| `nexus.env`                                 | Nexus environment variables         | `[{INSTALL4J_ADD_VM_PARAMS: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}]` |
 | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
 | `nexus.securityContext`                     | Security Context (for enabling official image use `fsGroup: 2000`) | `{}`     |

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -17,7 +17,7 @@ nexus:
     #    port: 5000
     #    secretName: registrySecret
   env:
-    - name: install4jAddVmParams
+    - name: INSTALL4J_ADD_VM_PARAMS
       value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "true"


### PR DESCRIPTION
Signed-off-by: Yuval Manor yuvalman958@gmail.com

Resolves #96 

The env var install4jAddVmParams does not exist in the nexus image.

Instead, the env var that should be used is INSTALL4J_ADD_VM_PARAMS.

We can see in the attached screenshot that only after adding the INSTALL4J_ADD_VM_PARAMS env var, the params of the jvm process in the nexus container was changed to the right values.

![image](https://user-images.githubusercontent.com/25984852/119136247-1b198100-ba48-11eb-881a-62e702e854b3.png)
