### PR TITLE
fix; serviceType to type

### DIFF
--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -115,7 +115,7 @@ service:
   enabled: true
   labels: {}
   annotations: {}
-  serviceType: ClusterIP
+  type: ClusterIP
 
 
 route:


### PR DESCRIPTION
when i traced templates, this was mistyped as "serviceType"
see below.

https://github.com/sonatype/helm3-charts/blob/5ac8a6b3a599e0038c3c24e437fda2af6f794485/charts/nexus-repository-manager/templates/service.yaml#L19