### PR TITLE
Additional ingress paths

### DIFF
--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -36,6 +36,9 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8081
+          {{- if .Values.ingress.additionalPaths}}
+{{ toYaml .Values.ingress.additionalPaths | indent 10 }}
+          {{- end }}
 
 {{ if .Values.nexus.docker.enabled }}
 {{ range $registry := .Values.nexus.docker.registries }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -108,7 +108,12 @@ ingress:
     #     - nexus.local
     #     - nexus-docker.local
     #     - nexus-docker-hosted.local
-
+  # Add additional paths (can be used for alb ingress actions)
+  # additionalPaths:
+  #   - path:
+  #     backend:
+  #       serviceName:
+  #       servicePort:
 
 service:
   name: nexus3


### PR DESCRIPTION
Adding in additional paths to values.yaml as well as ingress.yaml,
allowing the ability to leverage off annotations for load balancers,
more specifically configuring actions, to aid in the use of redirects.

@sonatype/integrations