### PR TITLE
Fix extraLabels rendering

### DIFF
--- a/charts/nexus-iq/templates/_helpers.tpl
+++ b/charts/nexus-iq/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.nexus.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/nexus-iq/templates/configmap.yaml
+++ b/charts/nexus-iq/templates/configmap.yaml
@@ -2,13 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "iqserver.fullname" . }}-conf
-  labels:
-{{ include "iqserver.labels" . | indent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 data:
   config.yml: |
 {{ toYaml .Values.configYaml | indent 4 }}

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -2,13 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "iqserver.fullname" . }}
-  labels:
-    {{- include "iqserver.labels" . | nindent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:

--- a/charts/nexus-iq/templates/ingress.yaml
+++ b/charts/nexus-iq/templates/ingress.yaml
@@ -10,13 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    {{- include "iqserver.labels" . | nindent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/nexus-iq/templates/persistentVolume.yaml
+++ b/charts/nexus-iq/templates/persistentVolume.yaml
@@ -4,13 +4,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Values.persistence.pdName }}
-  labels:
-{{ include "iqserver.labels" . | indent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}
@@ -30,13 +24,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Values.persistence.logpdName }}
-  labels:
-{{ include "iqserver.labels" . | indent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/charts/nexus-iq/templates/persistentVolumeClaim.yaml
+++ b/charts/nexus-iq/templates/persistentVolumeClaim.yaml
@@ -3,13 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "iqserver.fullname" . }}-data
-  labels:
-{{ include "iqserver.labels" . | indent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 {{- if .Values.persistence.annotations }}
   annotations:
 {{ toYaml .Values.persistence.annotations | indent 4 }}
@@ -32,13 +26,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "iqserver.fullname" . }}-log
-  labels:
-{{ include "iqserver.labels" . | indent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 {{- if .Values.persistence.annotations }}
   annotations:
 {{ toYaml .Values.persistence.annotations | indent 4 }}

--- a/charts/nexus-iq/templates/service.yaml
+++ b/charts/nexus-iq/templates/service.yaml
@@ -2,13 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "iqserver.fullname" . }}
-  labels:
-    {{- include "iqserver.labels" . | nindent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/nexus-iq/templates/serviceaccount.yaml
+++ b/charts/nexus-iq/templates/serviceaccount.yaml
@@ -3,13 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "iqserver.serviceAccountName" . }}
-  labels:
-    {{- include "iqserver.labels" . | nindent 4 }}
-    {{- if .Values.iq.extraLabels }}
-      {{- with .Values.iq.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/nexus-iq/templates/tests/test-connection.yaml
+++ b/charts/nexus-iq/templates/tests/test-connection.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "iqserver.fullname" . }}-test-connection"
-  labels:
-    {{- include "iqserver.labels" . | nindent 4 }}
+  labels: {{ include "iqserver.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/charts/nexus-repository-manager/templates/_helpers.tpl
+++ b/charts/nexus-repository-manager/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "nexus.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.nexus.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/nexus-repository-manager/templates/configmap-properties.yaml
+++ b/charts/nexus-repository-manager/templates/configmap-properties.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nexus.name" . }}-properties
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 data:
   nexus.properties: |
     {{- range $k, $v := .Values.nexus.properties.data }}

--- a/charts/nexus-repository-manager/templates/configmap.yaml
+++ b/charts/nexus-repository-manager/templates/configmap.yaml
@@ -3,13 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nexus.name" . }}-conf
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 data:
 {{ toYaml .Values.config.data | indent 2 }}
 {{- end }}

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -2,13 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nexus.fullname" . }}
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-  {{- if .Values.nexus.extraLabels }}
-    {{- with .Values.nexus.extraLabels }}
-      {{ toYaml . | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}
@@ -20,10 +14,8 @@ spec:
   selector:
     matchLabels:
       {{- include "nexus.selectorLabels" . | nindent 6 }}
-      {{- if .Values.nexus.extraSelectorLabels }}
-        {{- with .Values.nexus.extraSelectorLabels }}
-          {{ toYaml . | indent 6 }}
-        {{- end }}
+      {{- with .Values.nexus.extraSelectorLabels }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}      
   template:
     metadata:

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -6,13 +6,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    {{- include "nexus.labels" . | nindent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -44,13 +38,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
-  labels:
-    {{- include "nexus.labels" $ | nindent 4 }}
-    {{- if $.Values.nexus.extraLabels }}
-      {{- with $.Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" $ | nindent 4 }}
   {{- with $.Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/nexus-repository-manager/templates/psp-clusterrole.yaml
+++ b/charts/nexus-repository-manager/templates/psp-clusterrole.yaml
@@ -2,10 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-  {{- with .Values.nexus.extraLabels }}
-    {{ toYaml . | indent 4 }}
-  {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
   name: {{ template "nexus.name" . }}-psp-use
 rules:
 - apiGroups:

--- a/charts/nexus-repository-manager/templates/psp-rolebinding.yaml
+++ b/charts/nexus-repository-manager/templates/psp-rolebinding.yaml
@@ -2,10 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-  {{- with .Values.nexus.extraLabels }}
-    {{ toYaml . | indent 4 }}
-  {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
   name: {{ template "nexus.name" . }}-psp-use
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/nexus-repository-manager/templates/psp.yaml
+++ b/charts/nexus-repository-manager/templates/psp.yaml
@@ -2,10 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-  {{- with .Values.nexus.extraLabels }}
-    {{ toYaml . | indent 4 }}
-  {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
   name: {{ template "nexus.name" . }}
 spec:
   requiredDropCapabilities:

--- a/charts/nexus-repository-manager/templates/pv.yaml
+++ b/charts/nexus-repository-manager/templates/pv.yaml
@@ -4,13 +4,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Values.persistence.pdName }}
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.persistence.storageSize }}

--- a/charts/nexus-repository-manager/templates/pvc.yaml
+++ b/charts/nexus-repository-manager/templates/pvc.yaml
@@ -3,13 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nexus.fullname" . }}-data
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 {{- if .Values.persistence.annotations }}
   annotations:
 {{ toYaml .Values.persistence.annotations | indent 4 }}

--- a/charts/nexus-repository-manager/templates/secret.yaml
+++ b/charts/nexus-repository-manager/templates/secret.yaml
@@ -3,13 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "nexus.name" . }}-secret
-  labels:
-{{ include "nexus.labels" . | indent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 data:
 {{ toYaml .Values.secret.data | indent 2 }}
 {{- end}}

--- a/charts/nexus-repository-manager/templates/service.yaml
+++ b/charts/nexus-repository-manager/templates/service.yaml
@@ -8,13 +8,7 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
-  labels:
-    {{- include "nexus.labels" . | nindent 4 }}
-    {{- if .Values.nexus.extraLabels }}
-      {{- with .Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -23,10 +17,8 @@ spec:
       name: nexus-ui
   selector:
     {{- include "nexus.selectorLabels" . | nindent 4 }}
-    {{- if .Values.nexus.extraSelectorLabels }}
-      {{- with .Values.nexus.extraSelectorLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
+    {{- with .Values.nexus.extraSelectorLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 
 {{- if .Values.nexus.docker.enabled }}
@@ -40,13 +32,7 @@ metadata:
   annotations:
 {{ toYaml $.Values.service.annotations | indent 4 }}
 {{- end }}
-  labels:
-    {{- include "nexus.labels" $ | nindent 4 }}
-    {{- if $.Values.nexus.extraLabels }}
-      {{- with $.Values.nexus.extraLabels }}
-        {{ toYaml . | indent 4 }}
-      {{- end }}
-    {{- end }}
+  labels: {{ include "nexus.labels" $ | nindent 4 }}
 spec:
   type: {{ $.Values.service.type }}
   ports:

--- a/charts/nexus-repository-manager/templates/serviceaccount.yaml
+++ b/charts/nexus-repository-manager/templates/serviceaccount.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nexus.serviceAccountName" . }}
-  labels: {{- include "nexus.labels" . | nindent 4 }}
-  {{- if .Values.nexus.extraLabels }}
-    {{- with .Values.nexus.extraLabels }}
-      {{ toYaml . | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:  {{ include "nexus.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Fixes #103

Please see the associated issue (#103) for details of the problem being addressed. I have tested this fix manually.

I also took the opportunity to harmonize and DRY the rendering of labels across all templates by moving the rendering of `extraLabels` into the helper function. This should result in all resources having the same labels as before, with the exception of the iq-server `test-connection` test pod, which will now also have the `extraLabels` on it.