### PR TITLE
Kubernetes 1.22 support

### DIFF
--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -79,11 +79,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `iq.env`             | IQ server environment variables | `[{JAVA_OPTS: -Xms1200M -Xmx1200M}]` |
 | `iq.secretName`      | The name of a secret to mount inside the container  | See `values.yaml` |
 | `iq.secretMountName`      | Where in the container to mount the data from `secretName`  | See `values.yaml` |
-| `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
-| `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
-| `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
-| `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
-| `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+| `ingress.enabled`                           | Create an ingress for Nexus         | `false`                                 |
+| `ingress.className`                         | The name of the ingress class       | `nginx`                                 |
+| `ingress.annotations`                       | Annotations to enhance ingress configuration  | `[]`                          |
+| `ingress.tls`                       		  | TLS configuration                   | `[]`                                    |
+| `ingress.tls.hosts`                         | Hosts for the TLS secret            | `[]`                                    |
+| `ingress.tls.secretName`                    | Name of the secret storing TLS cert | `nil`                                   |
+| `ingress.hostUI`                            | Domain of the ui 					| `iq-server.demo`                        |
+| `ingress.hostUIPath`                        | Path of the ui 						| `/`                        			  |
+| `ingress.hostUIPathType`                    | Path type of the ui 			    | `Prefix`                    			  |
+| `ingress.hostAdmin`                         | Domain of the admin ui 				| `admin.iq-server.demo`                  |
+| `ingress.hostAdminPath`                     | Path of the admin ui 				| `/`                        			  |
+| `ingress.hostAdminPathType`                 | Path type of the admin ui 			| `Prefix`                    			  |
 | `deployment.preStart.command`               | Command to run before starting the IQ Server container  | `nil`                   |
 | `deployment.postStart.command`              | Command to run after starting the IQ Server container  | `nil`                    |
 | `deployment.terminationGracePeriodSeconds`  | Update termination grace period (in seconds)        | 120s                    |

--- a/charts/nexus-iq/templates/ingress-deprecated.yaml
+++ b/charts/nexus-iq/templates/ingress-deprecated.yaml
@@ -1,7 +1,7 @@
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "iqserver.fullname" . -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -12,14 +12,14 @@ metadata:
         {{ toYaml . | indent 4 }}
       {{- end }}
     {{- end }}
-  {{- if .Values.ingress.annotations }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.annotations }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
+    {{- end }}
+    {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -35,21 +35,15 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.hostUIPath }}
-            pathType: {{ .Values.ingress.hostUIPathType }}
             backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: 8070
+              serviceName: {{ $fullName }}
+              servicePort: 8070
     - host: {{ .Values.ingress.hostAdmin }}
       http:
         paths:
           - path: {{ .Values.ingress.hostAdminPath }}
-            pathType: {{ .Values.ingress.hostAdminPathType }}
             backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: 8070
+              serviceName: {{ $fullName }}
+              servicePort: 8071
 {{- end }}
 {{- end }}

--- a/charts/nexus-iq/templates/ingress.yaml
+++ b/charts/nexus-iq/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -76,13 +76,15 @@ service:
 
 ingress:
   enabled: false
-  annotations: {kubernetes.io/ingress.class: nginx}
-    # kubernetes.io/ingress.class: nginx
+  className: nginx
+  annotations: []
     # kubernetes.io/tls-acme: "true"
   hostUI: iq-server.demo
   hostUIPath: /
+  hostUIPathType: Prefix
   hostAdmin: admin.iq-server.demo
   hostAdminPath: /
+  hostAdminPathType: Prefix
 
   tls: []
     # - secretName: nexus-local-tls

--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -113,7 +113,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.properties.override`                 | Set to true to override default nexus.properties | `false`                    |
 | `nexus.properties.data`                 | A map of custom nexus properties if `override` is set to true | `nexus.scripts.allowCreation: true`            |
 | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
-| `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{kubernetes.io/ingress.class: nginx}`                          |
+| `ingress.className`                         | The name of the ingress class       | `nginx`                                 |
+| `ingress.annotations`                       | Annotations to enhance ingress configuration  | `[]`                          |
 | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
 | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
 | `tolerations`                               | tolerations list                    | `[]`                                    |

--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -112,11 +112,15 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
 | `nexus.properties.override`                 | Set to true to override default nexus.properties | `false`                    |
 | `nexus.properties.data`                 | A map of custom nexus properties if `override` is set to true | `nexus.scripts.allowCreation: true`            |
-| `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
+| `ingress.enabled`                           | Create an ingress for Nexus         | `false`                                 |
 | `ingress.className`                         | The name of the ingress class       | `nginx`                                 |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `[]`                          |
-| `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
-| `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+| `ingress.tls`                       		  | TLS configuration                   | `[]`                                    |
+| `ingress.tls.hosts`                         | Hosts for the TLS secret            | `[]`                                    |
+| `ingress.tls.secretName`                    | Name of the secret storing TLS cert | `nil`                                   |
+| `ingress.hostRepo`                          | Domain of nexus 					| `repo.demo`                             |
+| `ingress.hostPath`                          | Path of nexus 						| `/`                        			  |
+| `ingress.hostPathType`                      | Path type of nexus 			        | `Prefix`                    			  |
 | `tolerations`                               | tolerations list                    | `[]`                                    |
 | `config.enabled`                            | Enable configmap                    | `false`                                 |	
 | `config.mountPath`                          | Path to mount the config            | `/sonatype-nexus-conf`                  |	

--- a/charts/nexus-repository-manager/templates/ingress-deprecated.yaml
+++ b/charts/nexus-repository-manager/templates/ingress-deprecated.yaml
@@ -1,9 +1,9 @@
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nexus.fullname" . -}}
 {{- $svcPort := .Values.nexus.nexusPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -17,11 +17,11 @@ metadata:
   {{- if .Values.ingress.annotations }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -37,17 +37,14 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.hostPath }}
-            pathType: {{ .Values.ingress.hostPathType }}
             backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
 
 {{ if .Values.nexus.docker.enabled }}
 {{ range $registry := .Values.nexus.docker.registries }}
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
@@ -61,11 +58,11 @@ metadata:
   {{- if $.Values.ingress.annotations }}
   {{- with $.Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
   tls:
     - hosts:
       - {{ $registry.host | quote }}
@@ -75,12 +72,9 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Prefix
             backend:
-              service:
-                name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
-                port:
-                  number: {{ $registry.port }}
+              serviceName: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
+              servicePort: {{ $registry.port }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nexus-repository-manager/templates/ingress-deprecated.yaml
+++ b/charts/nexus-repository-manager/templates/ingress-deprecated.yaml
@@ -14,13 +14,13 @@ metadata:
         {{ toYaml . | indent 4 }}
       {{- end }}
     {{- end }}
-  {{- if .Values.ingress.annotations }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.annotations }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
+    {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:
@@ -55,13 +55,13 @@ metadata:
         {{ toYaml . | indent 4 }}
       {{- end }}
     {{- end }}
-  {{- if $.Values.ingress.annotations }}
-  {{- with $.Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if $.Values.ingress.annotations }}
+    {{- with $.Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
+    {{- end }}
+    {{- end }}
 spec:
   tls:
     - hosts:

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "nexus.fullname" . -}}
 {{- $svcPort := .Values.nexus.nexusPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -40,7 +40,7 @@ spec:
 {{ if .Values.nexus.docker.enabled }}
 {{ range $registry := .Values.nexus.docker.registries }}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -97,10 +97,11 @@ deployment:
 
 ingress:
   enabled: false
-  annotations: {kubernetes.io/ingress.class: nginx}
-    # kubernetes.io/ingress.class: nginx
+  className: nginx
+  annotations: []
     # kubernetes.io/tls-acme: "true"
   hostPath: /
+  hostPathType: Prefix
   hostRepo: repo.demo
   tls: []
     # - secretName: nexus-local-tls


### PR DESCRIPTION
move ingresses from removed `networking.k8s.io/v1beta1` api to `networking.k8s.io/v1` 
solves https://github.com/sonatype/helm3-charts/issues/74