### PR TITLE
INT-5698 whitelist the iq docker image at artifacthub

### DIFF
--- a/charts/nexus-iq/Chart.yaml
+++ b/charts/nexus-iq/Chart.yaml
@@ -33,3 +33,8 @@ icon: https://sonatype.github.io/helm3-charts/NexusIQServer_Vertical.svg
 maintainers:
   - email:  support@sonatype.com
     name: Sonatype
+annotations:
+  artifacthub.io/images: |
+    - name: nexus-iq-server
+      image: sonatype/nexus-iq-server:1.124.0
+      whitelisted: true


### PR DESCRIPTION
whitelist the iq docker image, so artifacthub stops showing F grade based on glibc and friends from underlying redhat 8.4 docker layer.
It'll show that it's disabled: 

<img width="279" alt="Screen Shot 2021-09-21 at 3 20 30 PM" src="https://user-images.githubusercontent.com/810358/134236992-4cb07f0d-afa0-423c-b743-32d2cf8d9e85.png">

JIRA: https://issues.sonatype.org/browse/INT-5698

