### PR TITLE
INT-5470 Updating serviceType to type

### DIFF
--- a/charts/nexus-repository-manager/templates/NOTES.txt
+++ b/charts/nexus-repository-manager/templates/NOTES.txt
@@ -2,18 +2,18 @@
 {{- if .Values.ingress.enabled }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $.Values.ingress.hostRepo }}{{ . }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $.Values.ingress.hostDocker }}{{ . }}
-{{- else if contains "NodePort" .Values.service.serviceType }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nexus.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   Your application is available at http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nexus.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nexus.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   {{- range $index, $port := .Values.service.ports }}
   Your application is available at http://$SERVICE_IP:{{ $port }}
   {{- end }}
-{{- else if contains "ClusterIP" .Values.service.serviceType }}
+{{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nexus.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8081:80
   Your application is available at http://127.0.0.1

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -115,7 +115,7 @@ service:
   enabled: true
   labels: {}
   annotations: {}
-  serviceType: ClusterIP
+  type: ClusterIP
 
 
 route:


### PR DESCRIPTION
Updating serviceType to type on:
* I updated `values.yaml` 
* I found some extra references in `templates/NOTES.txt`. Without the change on this file, I am not able to create the helm using `helm install nrxm charts/nexus-repository-manager`

When installing helm and checking logs, everything looks good:
![image](https://user-images.githubusercontent.com/20423049/135337714-6fda0937-77f1-4109-9747-e4f89e353db9.png)

JIRA: https://issues.sonatype.org/browse/INT-5470
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5470-serviceType-should-be-type/