### PR TITLE
INT-5549 | License unable to be automatically installed via Helm deployment

### DIFF
--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -136,6 +136,7 @@ persistence:
 configYaml:
   baseUrl: http://iq-server.demo
   sonatypeWork: /sonatype-work
+  licenseFile: /etc/nexus-iq-license/license_lic
   server:
     applicationConnectors:
       - type: http


### PR DESCRIPTION
License unable to be automatically installed via Helm deployment


Jira:  https://issues.sonatype.org/browse/INT-5549  

Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5549-license-automatically-installed/1/ 




