### PR TITLE
INT-6373 Removing global flag on git commands for deploy stage

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -28,8 +28,8 @@ dockerizedBuildPipeline(
     final branch = gitBranch(env)
 
     sh """
-      git config --global user.email "sonatype-ci@sonatype.com"
-      git config --global user.name "Sonatype CI"
+      git config user.email "sonatype-ci@sonatype.com"
+      git config user.name "Sonatype CI"
 
       git checkout ${branch}
       git add docs


### PR DESCRIPTION
This PR is to solve an intermittent issue on the release build for Helm Charts. 

Check this build error:
- https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Main%20Release%20Build/47/

And this Slack thread:
- https://sonatype.slack.com/archives/CCBVDFPJA/p1640105681210700

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/removing-git-global-config/