### PR TITLE
INT-6416 Adding config options for liveness and readiness probes

### DIFF
--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -76,9 +76,19 @@ The command removes all the Kubernetes components associated with the chart and 
 | `iq.memory`          | The amount of RAM to allocate                                | `1Gi`             |
 | `iq.licenseSecret`   | The base-64 encoded license file to be installed at startup  | `""`              |
 | `iq.configYaml`      | A YAML block which will be used as a configuration block for IQ Server. | See `values.yaml` |
-| `iq.env`             | IQ server environment variables | `[{JAVA_OPTS: -Xms1200M -Xmx1200M}]` |
-| `iq.secretName`      | The name of a secret to mount inside the container  | See `values.yaml` |
+| `iq.env`             | IQ server environment variables 							  | `[{JAVA_OPTS: -Xms1200M -Xmx1200M}]` |
+| `iq.secretName`      | The name of a secret to mount inside the container  		  | See `values.yaml` |
 | `iq.secretMountName`      | Where in the container to mount the data from `secretName`  | See `values.yaml` |
+| `iq.livenessProbe.initialDelaySeconds`   | LivenessProbe initial delay              | 10                |
+| `iq.livenessProbe.periodSeconds`         | Seconds between polls                    | 10                |
+| `iq.livenessProbe.failureThreshold`      | Number of attempts before failure   	  | 3                 |
+| `iq.livenessProbe.timeoutSeconds`        | Time in seconds after liveness probe times out    			   | 2 |
+| `iq.livenessProbe.successThreshold`      | Number of attempts for the probe to be considered successful  | 1 |
+| `iq.readinessProbe.initialDelaySeconds`  | ReadinessProbe initial delay        	  | 10                |
+| `iq.readinessProbe.periodSeconds`        | Seconds between polls               	  | 10                |
+| `iq.readinessProbe.failureThreshold`     | Number of attempts before failure   	  | 3                 |
+| `iq.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    		   | 2 |
+| `iq.readinessProbe.successThreshold`     | Number of attempts for the probe to be considered successful  | 1 |
 | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
 | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -47,10 +47,20 @@ spec:
             httpGet:
               path: /ping
               port: admin
+            initialDelaySeconds: {{ .Values.iq.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.iq.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.iq.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.iq.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.iq.livenessProbe.successThreshold }}
           readinessProbe:
             httpGet:
               path: /
               port: application
+            initialDelaySeconds: {{ .Values.iq.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.iq.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.iq.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.iq.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.iq.readinessProbe.successThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -49,16 +49,16 @@ spec:
             httpGet:
               path: /ping
               port: admin
-    {{- if .Values.iq.livenessProbe }}
-            {{- toYaml .Values.iq.livenessProbe | nindent 12 }}
-    {{- end }}
+              {{- if .Values.iq.livenessProbe }}
+                {{- toYaml .Values.iq.livenessProbe | nindent 12 }}
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: application
-    {{- if .Values.iq.livenessProbe }}
-            {{- toYaml .Values.iq.readinessProbe | nindent 12 }}
-    {{- end }} 
+              {{- if .Values.iq.livenessProbe }}
+                {{- toYaml .Values.iq.readinessProbe | nindent 12 }}
+              {{- end }} 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -47,20 +47,16 @@ spec:
             httpGet:
               path: /ping
               port: admin
-            initialDelaySeconds: {{ .Values.iq.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.iq.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.iq.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.iq.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.iq.livenessProbe.successThreshold }}
+    {{- if .Values.iq.livenessProbe }}
+            {{- toYaml .Values.iq.livenessProbe | nindent 12 }}
+    {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: application
-            initialDelaySeconds: {{ .Values.iq.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.iq.readinessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.iq.readinessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.iq.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.iq.readinessProbe.successThreshold }}
+    {{- if .Values.iq.livenessProbe }}
+            {{- toYaml .Values.iq.readinessProbe | nindent 12 }}
+    {{- end }} 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -30,18 +30,18 @@ iq:
       value: "-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
   # Configures the liveness probe for IQ pod
   livenessProbe:
-  #  initialDelaySeconds: 10
-  #  periodSeconds: 10
-  #  failureThreshold: 3
-  #  timeoutSeconds: 2
-  #  successThreshold: 1
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 2
+    successThreshold: 1
   # Configures the readiness probe for IQ pod
   readinessProbe:
-  #  initialDelaySeconds: 10
-  #  periodSeconds: 10
-  #  failureThreshold: 3
-  #  timeoutSeconds: 2
-  #  successThreshold: 1
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    failureThreshold: 10
+    timeoutSeconds: 2
+    successThreshold: 1
       
 # In conjunction with 'secretName' and 'secretMountName' above, this is an example of how to inject required password
 # secrets into the runtime environment, and how to modify the startup of the server to utilize custom Java SSL stores.

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -35,7 +35,7 @@ iq:
     failureThreshold: 3
     timeoutSeconds: 2
     successThreshold: 1
-  # Configures the liveness probe for IQ pod
+  # Configures the readiness probe for IQ pod
   readinessProbe:
     initialDelaySeconds: 10
     periodSeconds: 10

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -30,18 +30,18 @@ iq:
       value: "-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
   # Configures the liveness probe for IQ pod
   livenessProbe:
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    failureThreshold: 3
-    timeoutSeconds: 2
-    successThreshold: 1
+  #  initialDelaySeconds: 10
+  #  periodSeconds: 10
+  #  failureThreshold: 3
+  #  timeoutSeconds: 2
+  #  successThreshold: 1
   # Configures the readiness probe for IQ pod
   readinessProbe:
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    failureThreshold: 3
-    timeoutSeconds: 2
-    successThreshold: 1
+  #  initialDelaySeconds: 10
+  #  periodSeconds: 10
+  #  failureThreshold: 3
+  #  timeoutSeconds: 2
+  #  successThreshold: 1
       
 # In conjunction with 'secretName' and 'secretMountName' above, this is an example of how to inject required password
 # secrets into the runtime environment, and how to modify the startup of the server to utilize custom Java SSL stores.

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -28,6 +28,20 @@ iq:
   env:
     - name: JAVA_OPTS
       value: "-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+  # Configures the liveness probe for IQ pod
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 2
+    successThreshold: 1
+  # Configures the liveness probe for IQ pod
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 2
+    successThreshold: 1
       
 # In conjunction with 'secretName' and 'secretMountName' above, this is an example of how to inject required password
 # secrets into the runtime environment, and how to modify the startup of the server to utilize custom Java SSL stores.


### PR DESCRIPTION
Adding config options for liveness and readiness probes:
* I have updated the `deployment.yaml` template to add the new configuration options
* I have updated the `values.yaml` with the default values for the new configuration options
* I have updated the `README.md` file to add the new configuration options

JIRA: https://issues.sonatype.org/browse/INT-6416
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6416-adding-liveness-readiness-options/ 