### PR TITLE
INT-6161 Making sonatype-work string common

### DIFF
--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -95,7 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuring IQ Server
 
 You can define the `config.yml` for IQ Server in your `myvalues.yml` file on startup. 
-It is the `iq.configYaml` property. For more details, see the [Configuring IQ Server](https://help.sonatype.com/iqserver/configuring) help page.
+It is the `configYaml` property. For more details, see the [Configuring IQ Server](https://help.sonatype.com/iqserver/configuring) help page.
 Additionally the server can be started with JAVA_OPTS exported to the environment. This will be added to the server 
 process invocation and can be used for purposes such as changing the server memory settings. See the defaults set in
 [the values.yaml file](values.yaml).

--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -75,10 +75,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `iq.adminPort`       | Port of the application connector. Must match the value in the `configYaml` property | `8071`            |
 | `iq.memory`          | The amount of RAM to allocate                                | `1Gi`             |
 | `iq.licenseSecret`   | The base-64 encoded license file to be installed at startup  | `""`              |
-| `iq.configYaml`      | A YAML block which will be used as a configuration block for IQ Server. | See `values.yaml` |
 | `iq.env`             | IQ server environment variables | `[{JAVA_OPTS: -Xms1200M -Xmx1200M}]` |
 | `iq.secretName`      | The name of a secret to mount inside the container  | See `values.yaml` |
-| `iq.secretMountName`      | Where in the container to mount the data from `secretName`  | See `values.yaml` |
+| `iq.secretMountName` | Where in the container to mount the data from `secretName`  | See `values.yaml` |
+| `configYaml`         | A YAML block which will be used as a configuration block for IQ Server. | See `values.yaml` |
 | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
 | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: SONATYPE_WORK
+              value: {{ .Values.configYaml.sonatypeWork }}
 {{ toYaml .Values.iq.env | indent 12 }}
           ports:
             - name: application
@@ -54,7 +56,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /sonatype-work
+            - mountPath: {{ .Values.configYaml.sonatypeWork }}
               name: nxiq-pv-data
             - mountPath: /var/log/nexus-iq-server
               name: nxiq-pv-log

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -27,7 +27,7 @@ iq:
   secretMountName: #/etc/secret-volume
   env:
     - name: JAVA_OPTS
-      value: "-Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
+      value: "-Djava.util.prefs.userRoot=$(SONATYPE_WORK)/javaprefs"
       
 # In conjunction with 'secretName' and 'secretMountName' above, this is an example of how to inject required password
 # secrets into the runtime environment, and how to modify the startup of the server to utilize custom Java SSL stores.


### PR DESCRIPTION
Making `sonatype-work` string common for `values.yaml` and `deployment.yaml`

JIRA: https://issues.sonatype.org/browse/INT-6161
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6161-remove-sonatype-work-unused-env-var/