### PR TITLE
INT-6404 add owners in order to claim repository

### DIFF
--- a/docs/artifacthub-repo.yml
+++ b/docs/artifacthub-repo.yml
@@ -1,0 +1,25 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+#repositoryID:
+owners: # (optional, used to claim repository ownership)
+  - name: Sonatype
+    email: support@sonatype.com
+  - name: Adrian Powell
+    email: apowell@sonatype.com
+  - name: John Flinchbaugh
+    email: jflinchbaugh@sonatype.com
+  - name: Nicholas Blair
+    email: nblair@sonatype.com
+  - name: Hector Hurtado
+    email: hhurtado@sonatype.com
+  - name: Eduard Tita
+    email: etita@sonatype.com


### PR DESCRIPTION
First step towards creating a verified publisher is claiming the repository. We do that by creating an `artifact-repo.yml` file which lists the owners. The owners must include the list of emails which will be used to log into artifacthub.io. Rather than attempt to create a dummy account and deal with sharing passwords, adding all team members.

https://issues.sonatype.org/browse/INT-6404