### PR TITLE
INT-5705 upgrade beta apis for iq

### DIFF
--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -10,7 +10,7 @@
 
 These charts are designed to work out of the box with minikube using both ingess and ingress-dns addons.
 
-The current releases have been tested on minikube v1.25.1 running K8S v1.23.1.
+The current releases have been tested on minikube v1.25.1 running Kubernetes v1.23.1.
 
 ## Adding the Sonatype Repo to your Helm
 

--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -4,19 +4,21 @@
 
 ### Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.19+
 - PV provisioner support in the underlying infrastructure
 - Helm 3
 
 These charts are designed to work out of the box with minikube using both ingess and ingress-dns addons.
 
-The current releases have been tested on minikube v1.14.2 running k8s v1.19.2
+The current releases have been tested on minikube v1.25.1 running K8S v1.23.1.
 
-## Adding the repo
+## Adding the Sonatype Repo to your Helm
+
 To Add as a Helm Repo
 ```helm repo add sonatype https://sonatype.github.io/helm3-charts/```
 
 ## Testing the Chart
+
 To test the chart:
 ```bash
 $ helm install --dry-run --debug --generate-name ./

--- a/charts/nexus-iq/templates/NOTES.txt
+++ b/charts/nexus-iq/templates/NOTES.txt
@@ -1,11 +1,9 @@
-1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
+1. Your ingresses are available here:
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $.Values.ingress.hostUI }}{{ $.Values.ingress.hostUIPath }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $.Values.ingress.hostAdmin }}{{ $.Values.ingress.hostAdminPath }}
 {{- else if contains "NodePort" .Values.service.type }}
+1. Get the application URL by running these commands:
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "iqserver.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   Your application is available at http://$NODE_IP:$NODE_PORT
@@ -15,6 +13,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "iqserver.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   Your application is available at http://$SERVICE_IP:{{ .Values.service.appliocationPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
+1. Get the application URL by running these commands:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "iqserver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.iq.applicationPort}}:{{ .Values.iq.applicationPort}}
   Your application is available at http://127.0.0.1:{{ .Values.iq.applicationPort}}

--- a/charts/nexus-iq/templates/ingress.yaml
+++ b/charts/nexus-iq/templates/ingress.yaml
@@ -2,11 +2,7 @@
 {{- $fullName := include "iqserver.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/nexus-iq/templates/ingress.yaml
+++ b/charts/nexus-iq/templates/ingress.yaml
@@ -33,14 +33,20 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.hostUIPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 8070
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 8070
     - host: {{ .Values.ingress.hostAdmin }}
       http:
         paths:
           - path: {{ .Values.ingress.hostAdminPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 8071
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 8071
 {{- end }}

--- a/charts/nexus-iq/tests/ingress_test.yaml
+++ b/charts/nexus-iq/tests/ingress_test.yaml
@@ -36,8 +36,7 @@ tests:
 
       - equal:
           path: metadata.annotations
-          value:
-            kubernetes.io/ingress.class: nginx
+          value: null
 
       - equal:
           path: spec
@@ -46,21 +45,24 @@ tests:
               - host: iq-server.demo
                 http:
                   paths:
-                  - backend:
-                      serviceName: RELEASE-NAME-nexus-iq-server
-                      servicePort: 8070
-                    path: /
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: RELEASE-NAME-nexus-iq-server
+                          port:
+                            number: 8070
               - host: admin.iq-server.demo
                 http:
                   paths:
-                  - backend:
-                      serviceName: RELEASE-NAME-nexus-iq-server
-                      servicePort: 8071
-                    path: /
-  - it: doesn't render when disabled
-    set:
-      ingress:
-        enabled: false
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: RELEASE-NAME-nexus-iq-server
+                          port:
+                            number: 8071
+  - it: is disabled by default
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/nexus-iq/tests/ingress_test.yaml
+++ b/charts/nexus-iq/tests/ingress_test.yaml
@@ -1,0 +1,66 @@
+suite: ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: renders with defaults
+    set:
+      ingress:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nexus-iq-server
+
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/instance]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/managed-by]
+          value: Helm
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: nexus-iq-server
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: \d+\.\d+\.\d+
+      - matchRegex:
+          path: metadata.labels.[helm.sh/chart]
+          pattern: nexus-iq-server-\d+\.\d+\.\d+
+
+      - equal:
+          path: metadata.annotations
+          value:
+            kubernetes.io/ingress.class: nginx
+
+      - equal:
+          path: spec
+          value:
+            rules:
+              - host: iq-server.demo
+                http:
+                  paths:
+                  - backend:
+                      serviceName: RELEASE-NAME-nexus-iq-server
+                      servicePort: 8070
+                    path: /
+              - host: admin.iq-server.demo
+                http:
+                  paths:
+                  - backend:
+                      serviceName: RELEASE-NAME-nexus-iq-server
+                      servicePort: 8071
+                    path: /
+  - it: doesn't render when disabled
+    set:
+      ingress:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/nexus-iq/tests/ingress_test.yaml
+++ b/charts/nexus-iq/tests/ingress_test.yaml
@@ -62,7 +62,24 @@ tests:
                           name: RELEASE-NAME-nexus-iq-server
                           port:
                             number: 8071
+
   - it: is disabled by default
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: renders with tls config when provided
+    set:
+      ingress:
+        enabled: true
+        tls:
+          - secretName: nexus-tls-local
+            hosts:
+              - iq.host
+    asserts:
+      - equal:
+          path: spec.tls
+          value:
+            - secretName: nexus-tls-local
+              hosts:
+                - iq.host

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -91,17 +91,16 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/tls-acme: "true"
   hostUI: iq-server.demo
   hostUIPath: /
   hostAdmin: admin.iq-server.demo
   hostAdminPath: /
 
-  tls: []
-    # - secretName: nexus-local-tls
-    #   hosts:
-    #     - iqserver.local
-    #     - admin.iqserver.local
+  # tls:
+  #   - secretName: nexus-local-tls
+  #     hosts:
+  #       - iq-server.demo
+  #       - admin.iq-server.demo
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -90,8 +90,7 @@ service:
 
 ingress:
   enabled: false
-  annotations: {kubernetes.io/ingress.class: nginx}
-    # kubernetes.io/ingress.class: nginx
+  annotations: {}
     # kubernetes.io/tls-acme: "true"
   hostUI: iq-server.demo
   hostUIPath: /


### PR DESCRIPTION
update Ingress to v1 for IQ.

JIRA: https://issues.sonatype.org/browse/INT-5705
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5705-upgrade-beta-apis-for-iq/