### PR TITLE
INT-5705 restore pod security policy for now

### DIFF
--- a/charts/nexus-repository-manager/README.md
+++ b/charts/nexus-repository-manager/README.md
@@ -143,6 +143,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `route.labels`          | Labels to be added to route                        | `{}` |
 | `route.annotations`     | Annotations to be added to route                   | `{}` |
 | `route.path`            | Host name of Route e.g jenkins.example.com         | nil |
+| `psp.create`            | Set to true to create PodSecurityPolicy            | `false` |
 | `serviceAccount.create` | Set to true to create ServiceAccount               | `true` |
 | `serviceAccount.annotations` | Set annotations for ServiceAccount               | `{}` |
 | `serviceAccount.name` | The name of the service account to use. Auto-generate if not set and create is true      | `{}` |

--- a/charts/nexus-repository-manager/templates/psp-clusterrole.yaml
+++ b/charts/nexus-repository-manager/templates/psp-clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.psp.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- with .Values.nexus.extraLabels }}
+    {{ toYaml . | indent 4 }}
+  {{- end }}
+  name: {{ template "nexus.name" . }}-psp-use
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "nexus.name" . }}
+    verbs:
+      - use
+{{- end -}}

--- a/charts/nexus-repository-manager/templates/psp-rolebinding.yaml
+++ b/charts/nexus-repository-manager/templates/psp-rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.psp.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- with .Values.nexus.extraLabels }}
+    {{ toYaml . | indent 4 }}
+  {{- end }}
+  name: {{ template "nexus.name" . }}-psp-use
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nexus.name" . }}-psp-use
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nexus.serviceAccountName" . }}
+{{- end -}}

--- a/charts/nexus-repository-manager/templates/psp.yaml
+++ b/charts/nexus-repository-manager/templates/psp.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.psp.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- with .Values.nexus.extraLabels }}
+    {{ toYaml . | indent 4 }}
+  {{- end }}
+  name: {{ template "nexus.name" . }}
+spec:
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - persistentVolumeClaim
+    - secret
+    - projected
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+{{- end }}

--- a/charts/nexus-repository-manager/tests/psp-clusterrole_test.yaml
+++ b/charts/nexus-repository-manager/tests/psp-clusterrole_test.yaml
@@ -1,0 +1,50 @@
+suite: psp-clusterrole
+templates:
+  - psp-clusterrole.yaml
+tests:
+  - it: is disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders with defaults
+    set:
+      psp:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/instance]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/managed-by]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: \d+\.\d+\.\d+
+      - matchRegex:
+          path: metadata.labels.[helm.sh/chart]
+          pattern: nexus-repository-manager-\d+\.\d+\.\d+
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: nexus-repository-manager
+      - equal:
+          path: metadata.annotations
+          value: null
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - policy
+              resources:
+                - podsecuritypolicies
+              resourceNames:
+                - nexus-repository-manager
+              verbs:
+                - use

--- a/charts/nexus-repository-manager/tests/psp-rolebinding_test.yaml
+++ b/charts/nexus-repository-manager/tests/psp-rolebinding_test.yaml
@@ -1,0 +1,50 @@
+suite: psp-rolebinding
+templates:
+  - psp-rolebinding.yaml
+tests:
+  - it: is disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders with defaults
+    set:
+      psp:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/instance]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/managed-by]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: \d+\.\d+\.\d+
+      - matchRegex:
+          path: metadata.labels.[helm.sh/chart]
+          pattern: nexus-repository-manager-\d+\.\d+\.\d+
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: nexus-repository-manager
+      - equal:
+          path: metadata.annotations
+          value: null
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: nexus-repository-manager-psp-use
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: RELEASE-NAME-nexus-repository-manager

--- a/charts/nexus-repository-manager/tests/psp_test.yaml
+++ b/charts/nexus-repository-manager/tests/psp_test.yaml
@@ -1,0 +1,67 @@
+suite: psp
+templates:
+  - psp.yaml
+tests:
+  - it: is disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders with defaults
+    set:
+      psp:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodSecurityPolicy
+      - equal:
+          path: apiVersion
+          value: policy/v1beta1
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/instance]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/managed-by]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: \d+\.\d+\.\d+
+      - matchRegex:
+          path: metadata.labels.[helm.sh/chart]
+          pattern: nexus-repository-manager-\d+\.\d+\.\d+
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: nexus-repository-manager
+      - equal:
+          path: metadata.annotations
+          value: null
+      - equal:
+          path: spec
+          value:
+            requiredDropCapabilities:
+              - ALL
+            volumes:
+              - configMap
+              - downwardAPI
+              - emptyDir
+              - persistentVolumeClaim
+              - secret
+              - projected
+            runAsUser:
+              rule: 'RunAsAny'
+            seLinux:
+              rule: RunAsAny
+            supplementalGroups:
+              rule: 'MustRunAs'
+              ranges:
+                # Forbid adding the root group.
+                - min: 1
+                  max: 65535
+            fsGroup:
+              rule: 'MustRunAs'
+              ranges:
+                # Forbid adding the root group.
+                - min: 1
+                  max: 65535

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -96,10 +96,10 @@ deployment:
   additionalVolumeMounts:
 
 ingress:
-  enabled: true
+  enabled: false
   annotations: {}
   hostPath: /
-  hostRepo: repo.mini
+  hostRepo: repo.demo
   # tls:
   #   - secretName: nexus-local-tls
   #     hosts:
@@ -169,4 +169,4 @@ serviceAccount:
   name: ""
 
 psp:
-  create: true
+  create: false

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -96,15 +96,14 @@ deployment:
   additionalVolumeMounts:
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
   hostPath: /
-  hostRepo: repo.demo
+  hostRepo: repo.mini
   # tls:
   #   - secretName: nexus-local-tls
   #     hosts:
   #       - repo.demo
-
 
 service:
   name: nexus3
@@ -112,7 +111,6 @@ service:
   labels: {}
   annotations: {}
   type: ClusterIP
-
 
 route:
   enabled: false
@@ -169,3 +167,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+psp:
+  create: true


### PR DESCRIPTION
On a previous PR, someone questioned the removal, so I dug in a little bit to realize I don't need to remove this just yet, since it still exists (while deprecated) but doesn't yet have a clear replacement. In some environments, the PSP configs allow the charts to create resources where they would not have otherwise.

JIRA: https://issues.sonatype.org/browse/INT-5705
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5705-restore-clusterrole-role/

