### PR TITLE
INT-5705 set security context to match container

### DIFF
--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 {{- if .Values.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 4 }}
+    {{ toYaml .Values.deployment.annotations | nindent 4 }}
 {{- end }}
 spec:
   replicas: 1
@@ -30,7 +30,7 @@ spec:
       annotations:
         checksum/configmap-properties: {{ include (print .Template.BasePath "/configmap-properties.yaml") $ | sha256sum }}
         {{- if .Values.nexus.podAnnotations }}
-{{ toYaml .Values.nexus.podAnnotations | indent 8}}
+          {{ toYaml .Values.nexus.podAnnotations | nindent 8}}
         {{- end }}
       labels:
         {{- include "nexus.selectorLabels" . | nindent 8 }}
@@ -38,15 +38,15 @@ spec:
       serviceAccountName: {{ include "nexus.serviceAccountName" . }}
       {{- if .Values.deployment.initContainers }}
       initContainers:
-{{ toYaml .Values.deployment.initContainers | indent 6 }}
+        {{ toYaml .Values.deployment.initContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.nexus.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nexus.nodeSelector | indent 8 }}
+        {{ toYaml .Values.nexus.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.nexus.hostAliases }}
       hostAliases:
-{{ toYaml .Values.nexus.hostAliases | indent 8 }}
+        {{ toYaml .Values.nexus.hostAliases | nindent 8 }}
       {{- end }}
       {{- if .Values.nexus.imagePullSecrets }}
       imagePullSecrets:
@@ -67,11 +67,11 @@ spec:
                 command: {{ .Values.deployment.postStart.command }}
           {{- end }}
           env:
-{{ toYaml .Values.nexus.env | indent 12 }}
+            {{ toYaml .Values.nexus.env | nindent 12 }}
           envFrom:
-{{ toYaml .Values.nexus.envFrom | indent 12 }}
+            {{ toYaml .Values.nexus.envFrom | nindent 12 }}
           resources:
-{{ toYaml .Values.nexus.resources | indent 12 }}
+            {{ toYaml .Values.nexus.resources | nindent 12 }}
           ports:
             - name: nexus-ui
               containerPort: {{ .Values.nexus.nexusPort }}
@@ -119,14 +119,14 @@ spec:
               readOnly: {{ .Values.secret.readOnly }}
             {{- end }}
             {{- if .Values.deployment.additionalVolumeMounts}}
-{{ toYaml .Values.deployment.additionalVolumeMounts | indent 12 }}
+              {{ toYaml .Values.deployment.additionalVolumeMounts | nindent 12 }}
             {{- end }}
         {{- if .Values.deployment.additionalContainers }}
-{{ toYaml .Values.deployment.additionalContainers | indent 8 }}
+          {{ toYaml .Values.deployment.additionalContainers | nindent 8 }}
         {{- end }}
       {{- if .Values.nexus.securityContext }}
       securityContext:
-{{ toYaml .Values.nexus.securityContext | indent 8 }}
+        {{ toYaml .Values.nexus.securityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: {{ template "nexus.name" . }}-data
@@ -155,9 +155,9 @@ spec:
             secretName: {{ template "nexus.name" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
-{{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
+          {{ toYaml .Values.deployment.additionalVolumes | nindent 8 }}
         {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{ toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -57,8 +57,6 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 

--- a/charts/nexus-repository-manager/tests/deployment_test.yaml
+++ b/charts/nexus-repository-manager/tests/deployment_test.yaml
@@ -1,8 +1,10 @@
 suite: deployment
 templates:
   - deployment.yaml
+  - configmap-properties.yaml
 tests:
   - it: renders with defaults
+    template: deployment.yaml
     asserts:
       - hasDocuments:
           count: 1
@@ -20,6 +22,9 @@ tests:
       - matchRegex:
           path: metadata.labels.[app.kubernetes.io/version]
           pattern: 3\.\d+\.\d+
+      - matchRegex:
+          path: spec.template.metadata.annotations.[checksum/configmap-properties]
+          pattern: .*
       - equal:
           path: spec.replicas
           value: 1
@@ -28,49 +33,53 @@ tests:
           value: Recreate
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: sonatype/nexus-repository-manager:3\.\d+\.\d+
-      - equal:
-          path: spec.template.metadata.annotations
-          value: {}
+          pattern: sonatype/nexus3:3\.\d+\.\d+
       - equal:
           path: spec.template.spec.containers[0].securityContext
-          value: {}
+          value: null
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
       - equal:
-          path: spec.template.spec.containers[0].env[0]
+          path: spec.template.spec.containers[0].env
           value:
-            name: SONATYPE_WORK
-            value: /sonatype-work
+            - name: INSTALL4J_ADD_VM_PARAMS
+              value: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+            - name: NEXUS_SECURITY_RANDOMPASSWORD
+              value: "true"
       - equal:
           path: spec.template.spec.containers[0].ports
           value: 
-            - name: application
-              containerPort: 8070
-              protocol: TCP
-            - name: admin
-              containerPort: 8071
-              protocol: TCP
+            - containerPort: 8081
+              name: nexus-ui
       - equal:
           path: spec.template.spec.containers[0].livenessProbe
           value:
+            failureThreshold: 6
             httpGet:
-              path: /ping
-              port: admin
-            initialDelaySeconds: 10
-            failureThreshold: 3
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 2
+              path: /
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
       - equal:
           path: spec.template.spec.containers[0].readinessProbe
           value:
+            failureThreshold: 6
             httpGet:
               path: /
-              port: application
+              port: 8081
             initialDelaySeconds: 30
-            failureThreshold: 10
             periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 10
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /nexus-data
+              name: nexus-repository-manager-data
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: nexus-repository-manager-data
+              persistentVolumeClaim:
+                claimName: RELEASE-NAME-nexus-repository-manager-data

--- a/charts/nexus-repository-manager/tests/deployment_test.yaml
+++ b/charts/nexus-repository-manager/tests/deployment_test.yaml
@@ -1,0 +1,76 @@
+suite: deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: renders with defaults
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: apiVersion
+          value: apps/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nexus-repository-manager
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/name]
+          pattern: nexus-repository-manager
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: 3\.\d+\.\d+
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: sonatype/nexus-repository-manager:3\.\d+\.\d+
+      - equal:
+          path: spec.template.metadata.annotations
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: SONATYPE_WORK
+            value: /sonatype-work
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value: 
+            - name: application
+              containerPort: 8070
+              protocol: TCP
+            - name: admin
+              containerPort: 8071
+              protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: admin
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /
+              port: application
+            initialDelaySeconds: 30
+            failureThreshold: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2

--- a/charts/nexus-repository-manager/tests/deployment_test.yaml
+++ b/charts/nexus-repository-manager/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
           pattern: 3\.\d+\.\d+
       - matchRegex:
           path: spec.template.metadata.annotations.[checksum/configmap-properties]
-          pattern: .*
+          pattern: .+
       - equal:
           path: spec.replicas
           value: 1

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -45,7 +45,7 @@ nexus:
   # The ports should only be changed if the nexus image uses a different port
   nexusPort: 8081
 
-  # Default UID and GID to match the nexus3 container.
+  # Default the pods UID and GID to match the nexus3 container.
   # Customize or remove these values from the securityContext as appropriate for
   # your deployment environment.
   securityContext:

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -46,7 +46,9 @@ nexus:
   nexusPort: 8081
 
   securityContext:
-    fsGroup: 2000
+    runAsUser: 200
+    runAsGroup: 200
+    fsGroup: 200
   podAnnotations: {}
   livenessProbe:
     initialDelaySeconds: 30

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -45,6 +45,9 @@ nexus:
   # The ports should only be changed if the nexus image uses a different port
   nexusPort: 8081
 
+  # Default UID and GID to match the nexus3 container.
+  # Customize or remove these values from the securityContext as appropriate for
+  # your deployment environment.
   securityContext:
     runAsUser: 200
     runAsGroup: 200


### PR DESCRIPTION
To alleviate the need for the deprecated PodSecurityPolicy, set and document the default securityContext on the pod.
Also a bit of formatting cleanup.

JIRA: https://issues.sonatype.org/browse/INT-5705
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5705-set-securityContext-to-match-container/