### PR TITLE
INT-6531 switch to newer ingressClassName

### DIFF
--- a/charts/nexus-iq/templates/ingress.yaml
+++ b/charts/nexus-iq/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/nexus-iq/tests/ingress_test.yaml
+++ b/charts/nexus-iq/tests/ingress_test.yaml
@@ -36,12 +36,13 @@ tests:
 
       - equal:
           path: metadata.annotations
-          value: 
-            kubernetes.io/ingress.class: nginx
+          value:
+            null
 
       - equal:
           path: spec
           value:
+            ingressClassName: nginx
             rules:
               - host: iq-server.demo
                 http:

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -91,8 +91,8 @@ service:
 
 ingress:
   enabled: false
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
+  ingressClassName: nginx
+  annotations: {}
   hostUI: iq-server.demo
   hostUIPath: /
   hostAdmin: admin.iq-server.demo

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/nexus-repository-manager/tests/ingress_test.yaml
+++ b/charts/nexus-repository-manager/tests/ingress_test.yaml
@@ -32,7 +32,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            kubernetes.io/ingress.class: nginx
+            null
 
       - documentIndex: 0
         equal:
@@ -42,6 +42,7 @@ tests:
         equal:
           path: spec
           value:
+            ingressClassName: nginx
             rules:
               - host: repo.demo
                 http:
@@ -90,8 +91,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            kubernetes.io/ingress.class: nginx
-
+            null
       - documentIndex: 0
         equal:
           path: metadata.name

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -102,8 +102,8 @@ deployment:
 
 ingress:
   enabled: false
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
+  ingressClassName: nginx
+  annotations: {}
   hostPath: /
   hostRepo: repo.demo
   # tls:


### PR DESCRIPTION
Switch from older ingress.class annotation to newer standard ingressClassName.  This continues to work in docker desktop like the annotation did.

JIRA: https://issues.sonatype.org/browse/INT-6531
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6531-ingressClassName/