### PR TITLE
Propose Fix issue #158

### DIFF
--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -76,9 +76,9 @@ spec:
             - name: nexus-ui
               containerPort: {{ .Values.nexus.nexusPort }}
             {{- if .Values.nexus.docker.enabled }}
-            {{- range .Values.nexus.docker.registries }}
-            - name: docker-{{ .port }}
-              containerPort: {{ .port }}
+            {{- range $index, $registry := .Values.nexus.docker.registries }}
+            - name: docker-{{ $index }}-{{ $registry.port }}
+              containerPort: {{ $registry.port }}
             {{- end }}
             {{- end }}
           livenessProbe:

--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -44,12 +44,12 @@ spec:
                   number: 8081
 
 {{ if .Values.nexus.docker.enabled }}
-{{ range $registry := .Values.nexus.docker.registries }}
+{{ range $index, $registry := .Values.nexus.docker.registries }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
+  name: {{ $fullName | trunc 46 }}-{{ $index }}-docker-{{ $registry.port }}
   labels:
     {{- include "nexus.labels" $ | nindent 4 }}
     {{- if $.Values.nexus.extraLabels }}
@@ -74,7 +74,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName | trunc 49 }}-docker-{{ $registry.port }}
+                name: {{ $fullName | trunc 46 }}-{{ $index }}-docker-{{ $registry.port }}
                 port:
                   number: {{ $registry.port }}
 {{- end }} {{- /* range of nexus.docker.registries */ -}}

--- a/charts/nexus-repository-manager/templates/service.yaml
+++ b/charts/nexus-repository-manager/templates/service.yaml
@@ -30,12 +30,12 @@ spec:
     {{- end }}
 
 {{- if .Values.nexus.docker.enabled }}
-{{- range $registry := .Values.nexus.docker.registries }}
+{{- range $index, $registry := .Values.nexus.docker.registries }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "nexus.fullname" $ | trunc 49 }}-docker-{{ $registry.port }}
+  name: {{ include "nexus.fullname" $ | trunc 46 }}-{{ $index }}-docker-{{ $registry.port }}
 {{- if $.Values.service.annotations }}
   annotations:
 {{ toYaml $.Values.service.annotations | indent 4 }}


### PR DESCRIPTION
This fix avoid duplicate service name when 2 or more registries have same port. Introduced index of range for naming of containers, services and ingresses