### PR TITLE
INT-5720 remove unused iq.memory setting

### DIFF
--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -75,7 +75,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `iq.imagePullSecret` | The base-64 encoded secret to pull a container from Red Hat  | `""`              |
 | `iq.applicationPort` | Port of the application connector. Must match the value in the `configYaml` property | `8070`            |
 | `iq.adminPort`       | Port of the application connector. Must match the value in the `configYaml` property | `8071`            |
-| `iq.memory`          | The amount of RAM to allocate                                | `1Gi`             |
 | `iq.licenseSecret`   | The base-64 encoded license file to be installed at startup  | `""`              |
 | `iq.env`             | IQ server environment variables | `[{JAVA_OPTS: -Xms1200M -Xmx1200M}]` |
 | `iq.secretName`      | The name of a secret to mount inside the container  | See `values.yaml` |

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -17,7 +17,6 @@ iq:
   hostname: iq-server.demo
   applicationPort: 8070
   adminPort: 8071
-  memory: 1Gi
   # base 64 encoded license file with no line breaks
   licenseSecret: ""
   # add this line with this file path and the `licenseSecret` above to autoconfigure licensing


### PR DESCRIPTION
Didn't work. Use JAVA_OPTS instead if you want to configure memory in a meaningful way.

JIRA: https://issues.sonatype.org/browse/INT-5720
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-5720-unused-iq-memory/