### PR TITLE
fix ingress classname for docker registry

### DIFF
--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -62,6 +62,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - hosts:
       - {{ $registry.host | quote }}


### PR DESCRIPTION
The ingressClassName entry is missing on the docker registry, append the ingressClassname to docker registries