### PR TITLE
INT-6585 upload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,3 @@ Use `minikube ip` to get the address
 
 Docs for Ingress-dns are here
 https://github.com/kubernetes/minikube/tree/master/deploy/addons/ingress-dns
-
-#### 413 Errors with Nginx
-
-The default setting for Nginx allows for very small upload sizes. Add this annotation to the ingress 
-for each product to remove the limit:
-```
-nginx.ingress.kubernetes.io/proxy-body-size: "0"
-```

--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -121,10 +121,6 @@ The license file can be installed via the UI when IQ server is running, or it ca
 If you leave the `licenseFile` field empty/commented, IQ Server will start and prompt you to manually install the license 
 when you first enter the GUI.
 
-## 413 Errors
-
-The default setting for Nginx allows for very small upload sizes. Add this annotation to the ingress for each product to remove the limit: nginx.ingress.kubernetes.io/proxy-body-size: "0"
- 
 ## Specifying custom Java keystore/truststore
 
 There is an example of how to implement this in [the values.yaml file](values.yaml) using secrets to store both the

--- a/charts/nexus-iq/tests/ingress_test.yaml
+++ b/charts/nexus-iq/tests/ingress_test.yaml
@@ -37,7 +37,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            null
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
       - equal:
           path: spec

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -93,7 +93,8 @@ service:
 ingress:
   enabled: false
   ingressClassName: nginx
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
   hostUI: iq-server.demo
   hostUIPath: /
   hostAdmin: admin.iq-server.demo

--- a/charts/nexus-repository-manager/tests/ingress_test.yaml
+++ b/charts/nexus-repository-manager/tests/ingress_test.yaml
@@ -32,7 +32,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            null
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
       - documentIndex: 0
         equal:
@@ -91,7 +91,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            null
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+
       - documentIndex: 0
         equal:
           path: metadata.name

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -103,7 +103,8 @@ deployment:
 ingress:
   enabled: false
   ingressClassName: nginx
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
   hostPath: /
   hostRepo: repo.demo
   # tls:


### PR DESCRIPTION
Apply an nginx annotation to remove the limit of upload size, which is often needed for nxrm and for iq.

JIRA: https://issues.sonatype.org/browse/INT-6585
Bulid: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6585-upload-limits/