### PR TITLE
Fixing imagepullsecrets

### DIFF
--- a/charts/nexus-repository-manager/Chart.yaml
+++ b/charts/nexus-repository-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-repository-manager
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 38.1.0
+version: 38.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.38.1

--- a/charts/nexus-repository-manager/templates/deployment.yaml
+++ b/charts/nexus-repository-manager/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       {{- if .Values.nexus.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.nexus.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -71,9 +71,8 @@ nexus:
   #   hostnames:
   #   - "example.com"
   #   - "www.example.com"
+  imagePullSecrets: []
 
-
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
ImagePullSecrets is not working as intended. When the value is defined, the kubernetes manifest is not building correctly, resulting in validation errors.

This will need to be fixed in order to support passing secrets for pulling images from private repositories.

The issue has been raised before, but it seems a fix hasn't been pushed:
- https://github.com/sonatype/helm3-charts/issues/105
- https://github.com/sonatype/helm3-charts/pull/73