### PR TITLE
INT-6696 docker ingress class name

### DIFF
--- a/charts/nexus-repository-manager/templates/ingress.yaml
+++ b/charts/nexus-repository-manager/templates/ingress.yaml
@@ -62,6 +62,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if $.Values.ingress.ingressClassName }}
+  ingressClassName: {{ $.Values.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - hosts:
       - {{ $registry.host | quote }}

--- a/charts/nexus-repository-manager/tests/ingress_test.yaml
+++ b/charts/nexus-repository-manager/tests/ingress_test.yaml
@@ -122,6 +122,7 @@ tests:
         equal:
           path: spec
           value:
+            ingressClassName: nginx
             rules:
               - host: docker.repo.demo
                 http:

--- a/charts/nexus-repository-manager/tests/ingress_test.yaml
+++ b/charts/nexus-repository-manager/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+---
 suite: ingress
 templates:
   - ingress.yaml
@@ -119,7 +120,7 @@ tests:
                             number: 5000
             tls:
               - hosts:
-                - docker.repo.demo
+                  - docker.repo.demo
                 secretName: registry-secret
 
   - it: is disabled by default

--- a/charts/nexus-repository-manager/tests/ingress_test.yaml
+++ b/charts/nexus-repository-manager/tests/ingress_test.yaml
@@ -98,7 +98,22 @@ tests:
         equal:
           path: metadata.name
           value: RELEASE-NAME-nexus-repository-manager
-
+      - documentIndex: 0
+        equal:
+          path: spec
+          value:
+            ingressClassName: nginx
+            rules:
+              - host: repo.demo
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: RELEASE-NAME-nexus-repository-manager
+                          port:
+                            number: 8081
       - documentIndex: 1
         equal:
           path: metadata.name
@@ -122,7 +137,88 @@ tests:
               - hosts:
                   - docker.repo.demo
                 secretName: registry-secret
+  - it: we can exclude ingressClassName for repo ingress and docker ingress
+    set:
+      ingress:
+        enabled: true
+        ingressClassName: {}
+      nexus:
+        docker:
+          enabled: true
+          registries:
+            - host: docker.repo.demo
+              port: 5000
+              secretName: registry-secret
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Ingress
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/instance]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/managed-by]
+          value: Helm
+      - matchRegex:
+          path: metadata.labels.[app.kubernetes.io/version]
+          pattern: \d+\.\d+\.\d+
+      - matchRegex:
+          path: metadata.labels.[helm.sh/chart]
+          pattern: nexus-repository-manager-\d+\.\d+\.\d+
+      - equal:
+          path: metadata.labels.[app.kubernetes.io/name]
+          value: nexus-repository-manager
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-nexus-repository-manager
+      - documentIndex: 0
+        equal:
+          path: spec
+          value:
+            rules:
+              - host: repo.demo
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: RELEASE-NAME-nexus-repository-manager
+                          port:
+                            number: 8081
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-nexus-repository-manager-docker-5000
+      - documentIndex: 1
+        equal:
+          path: spec
+          value:
+            rules:
+              - host: docker.repo.demo
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: RELEASE-NAME-nexus-repository-manager-docker-5000
+                          port:
+                            number: 5000
+            tls:
+              - hosts:
+                  - docker.repo.demo
+                secretName: registry-secret
   - it: is disabled by default
     asserts:
       - hasDocuments:

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -16,7 +16,7 @@ nexus:
     # registries:
     #   - host: chart.local
     #     port: 5000
-    #     secretName: registrySecret
+    #     secretName: registry-secret
   env:
     # minimum recommended memory settings for a small, person instance from
     # https://help.sonatype.com/repomanager3/product-information/system-requirements


### PR DESCRIPTION
#### Description of Change

* add the ingressClassName to the docker ingress like it was to the repo ingress.
* some small cleanups
* extra tests around ingress

JIRA: https://issues.sonatype.org/browse/INT-6696
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6696-docker-ingressClassName/

I'm still putting together a proper plan to test docker repo end-to-end. It is provably listening now, but I need to work around certificates, since it's TLS.