### PR TITLE
INT-6828 add javaprefs into OPTS to preserve license across restarts

### DIFF
--- a/charts/nexus-repository-manager/tests/deployment_test.yaml
+++ b/charts/nexus-repository-manager/tests/deployment_test.yaml
@@ -44,12 +44,17 @@ tests:
           path: spec.template.spec.containers[0].env
           value:
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: -Xms2703M -Xmx2703M -XX:MaxDirectMemorySize=2703M -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+              value: |-
+                -Xms2703M -Xmx2703M
+                -XX:MaxDirectMemorySize=2703M
+                -XX:+UnlockExperimentalVMOptions
+                -XX:+UseCGroupMemoryLimitForHeap
+                -Djava.util.prefs.userRoot=/nexus-data/javaprefs
             - name: NEXUS_SECURITY_RANDOMPASSWORD
               value: "true"
       - equal:
           path: spec.template.spec.containers[0].ports
-          value: 
+          value:
             - containerPort: 8081
               name: nexus-ui
       - equal:

--- a/charts/nexus-repository-manager/values.yaml
+++ b/charts/nexus-repository-manager/values.yaml
@@ -21,7 +21,12 @@ nexus:
     # minimum recommended memory settings for a small, person instance from
     # https://help.sonatype.com/repomanager3/product-information/system-requirements
     - name: INSTALL4J_ADD_VM_PARAMS
-      value: "-Xms2703M -Xmx2703M -XX:MaxDirectMemorySize=2703M -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      value: |-
+        -Xms2703M -Xmx2703M
+        -XX:MaxDirectMemorySize=2703M
+        -XX:+UnlockExperimentalVMOptions
+        -XX:+UseCGroupMemoryLimitForHeap
+        -Djava.util.prefs.userRoot=/nexus-data/javaprefs
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "true"
   properties:


### PR DESCRIPTION
#### Description of Change

set javaprefs to /nexus-data so the license is preserved across restarts of the pod.

JIRA: https://issues.sonatype.org/browse/INT-6828
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6828-preserve-license/