### PR TITLE
INT-6852 use helm 3.9.0 for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 #
 
-FROM docker-all.repo.sonatype.com/alpine/helm:3.7.2
+FROM docker-all.repo.sonatype.com/alpine/helm:3.9.0
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh


### PR DESCRIPTION
#### Description of Change
upgrade test docker image to use helm 3.9.0

JIRA: https://issues.sonatype.org/browse/INT-6852
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-6852-helm-3.9.0/
