### PR TITLE
remove references to nxrm from build

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -19,18 +19,16 @@ final jira = [
 
 final jiraVersionMappings = [
   'nexus-iq-server': 'helm-iq',
-  'nexus-repository-manager': 'helm-nxrm',
 ]
 
 final chartLocation = [
   'nexus-iq-server': 'nexus-iq',
-  'nexus-repository-manager': 'nexus-repository-manager',
 ]
 
 properties([
   parameters([
     choice(
-      choices: ['', 'nexus-iq-server', 'nexus-repository-manager'],
+      choices: ['', 'nexus-iq-server'],
       name: 'chart',
       description: 'Chart to deploy.',
     ),

--- a/build.sh
+++ b/build.sh
@@ -18,15 +18,12 @@ set -e
 
 # lint yaml of charts
 helm lint charts/nexus-iq
-helm lint charts/nexus-repository-manager
 
 # unit test
 (cd charts/nexus-iq; helm unittest -3 -t junit -o test-output.xml .)
-(cd charts/nexus-repository-manager; helm unittest -3 -t junit -o test-output.xml .)
 
 # package the charts into tgz archives
 helm package charts/nexus-iq --destination docs
-helm package charts/nexus-repository-manager --destination docs
 
 # index the existing tgz archives
 cd docs


### PR DESCRIPTION
#### Description of Change
NXRM team is taking over the nxrm chart with their own [repo](https://github.com/sonatype/nxrm3-helm-repository) and have removed the chart from this repo, so this PR removes it the rest of the way from the build.

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/remove-nxrm-from-build/

