### PR TITLE
Fix formatting for terraform parse error

### DIFF
--- a/charts/nexus-iq/templates/_helpers.tpl
+++ b/charts/nexus-iq/templates/_helpers.tpl
@@ -70,9 +70,5 @@ Create the value for internal host system value from the image repository value.
   {{- $systems := dict "" "" -}}
   {{- $_ := set $systems "sonatype/nexus-iq-server" "Helm+Docker" -}}
   {{- $_ := set $systems "registry.connect.redhat.com/sonatype/nexus-iq-server" "Helm+RedHat" -}}
-  {{- .Values.image.repository
-      | default ""
-      | get $systems
-      | default "Helm+Other"
-    -}}
+  {{ .Values.image.repository | default "" | get $systems | default "Helm+Other" }}
 {{- end -}}


### PR DESCRIPTION
#### Description of Change
Terraform was returning with an error: unclosed action. This changes the format from multiline to single line to make terraform happy.

Jira: https://issues.sonatype.org/browse/CLM-22042
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/fix-formatting-for-terraform-2/