### PR TITLE
NEXUS-34129 - Include information about the resiliency helm charts located in  nxrm3-helm-repository

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,10 @@
 ## Helm3 Charts for Sonatype Products
+### AWS Single-Instance Resilient Nexus Repository Manager Chart
+These charts will deploy a Nexus Repository Manager instance to an AWS EKS cluster.
 
+The current release has been tested on AWS EKS running Kubernetes version 1.21
+
+### Single-Instance Nexus Repository Manager OSS/Pro Kubernetes Chart
 These charts are designed to work out of the box with minikube using both Ingress
 and Ingress DNS addons.
 
@@ -11,12 +16,14 @@ The current releases have been tested on minikube v1.25.1 running Kubernetes v1.
 
 ### Install a Server
 
-- NXRM: `helm install nexus-repo sonatype/nexus-repository-manager`
+- Single-Instance Nexus Repository Manager OSS/Pro: `helm install nexus-repo sonatype/nexus-repository-manager`
+- AWS Single-Instance Resilient Nexus Repository Manager: `helm install nxrm sonatype/nxrm-aws-resiliency --values values.yaml`
 - Nexus IQ: `helm install nexus-iq sonatype/nexus-iq-server`
 
 ### Get the Values for Configuring a Chart
 
-- NXRM: `helm show values sonatype/nexus-repository-manager`
+- Single-Instance Nexus Repository Manager OSS/Pro: `helm show values sonatype/nexus-repository-manager`
+- AWS Single-Instance Resilient Nexus Repository Manager: `helm show values sonatype/nxrm-aws-resiliency`
 - Nexus IQ: `helm show values sonatype/nexus-iq-server`
 
 Capture that output as your own `values.yaml` file, and provide it to the `helm install` 


### PR DESCRIPTION

NEXUS-34129 involves publishing the aws resiliency helm chart located in nxrm3-helm-repository to artifact hub. This change updates the index.md to include information about the aforementioned helm chart.
