### PR TITLE
Uncomment fsgroup by default in provided values file

### DIFF
--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -75,8 +75,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
-#  fsGroup: 2000
+podSecurityContext:
+  fsGroup: 2000
 
 securityContext: {}
 #  capabilities:


### PR DESCRIPTION
#### Description of Change
The default values file should include `fsGroup: 2000` under the `podSecurityContext` map. Mounted volumes will not be writeable without this permission, which means users installing this chart for the first time will have containers stuck in a `CrashLoopBackOff` unless this value is a default setting.
#### Things to Do Before Submitting

* Have you signed the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)?
* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change?
