### PR TITLE
Added initContainer for changing file ownership

### DIFF
--- a/charts/nexus-iq/Chart.yaml
+++ b/charts/nexus-iq/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus-iq-server
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 143.0.0
+version: 143.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.143.0

--- a/charts/nexus-iq/README.md
+++ b/charts/nexus-iq/README.md
@@ -52,7 +52,10 @@ The default login for the IQ Server is admin/admin123
 $ helm upgrade nexus-iq sonatype/nexus-iq-server [--version v91.0.0]
 ```
 
-Note: optional version flag shown
+
+Note: 
+ - optional version flag shown.
+ - When upgrading from older IQ version, set initContainers.enabled to true for changing the file ownership to new uid (1000)
 
 ## Uninstalling the Chart
 
@@ -90,6 +93,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `iq.readinessProbe.failureThreshold`           | Number of attempts before failure                                                                                                                                                       | 3                                                           |
 | `iq.readinessProbe.timeoutSeconds`             | Time in seconds after readiness probe times out                                                                                                                                         | 2                                                           |
 | `iq.readinessProbe.successThreshold`           | Number of attempts for the probe to be considered successful                                                                                                                            | 1                                                           |
+| `initContainers.enabled`                       | Change file ownership during IQ upgrade from older version                                                                                                                              | false                                                       |
 | `configYaml`                                   | A YAML block which will be used as a configuration block for IQ Server.                                                                                                                 | See `values.yaml`                                           |
 | `ingress.enabled`                              | Create an ingress for Nexus                                                                                                                                                             | `false`                                                     |
 | `ingress.annotations`                          | Annotations to enhance ingress configuration                                                                                                                                            | `{}`                                                        |

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -28,6 +28,23 @@ spec:
       serviceAccountName: {{ include "iqserver.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers.enabled }}
+      initContainers:
+        - name: chown-vols
+          image: "busybox:latest"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+          command: ['sh', '-c', 'chown -R {{ .Values.initContainers.iqUser }}:{{ .Values.initContainers.iqGroup }} /var/log/nexus-iq-server {{ .Values.configYaml.sonatypeWork }}']          
+          volumeMounts:
+            - mountPath: {{ .Values.configYaml.sonatypeWork }}
+              name: nxiq-pv-data
+            - mountPath: /var/log/nexus-iq-server
+              name: nxiq-pv-log
+            - mountPath: /etc/nexus-iq-server
+              name: config-volume
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: true
-          command: ['sh', '-c', 'chown -R {{ .Values.initContainers.iqUser }}:{{ .Values.initContainers.iqGroup }} /var/log/nexus-iq-server {{ .Values.configYaml.sonatypeWork }}']          
+          command: ['sh', '-c', 'chown -R {{ .Values.initContainers.updateUser }}:{{ .Values.initContainers.updateGroup }} /var/log/nexus-iq-server {{ .Values.configYaml.sonatypeWork }}']          
           volumeMounts:
             - mountPath: {{ .Values.configYaml.sonatypeWork }}
               name: nxiq-pv-data

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -17,6 +17,12 @@ imagePullSecrets:
 # kubernetes secret
 #   - name: <pull-secret-name>
 
+# Change initContainer enabled to true, to change file ownership to new UID, when upgrading from old IQ version (<120, <100)
+initContainers:
+  enabled: false
+  iqUser: 1000
+  iqGroup: 1000
+
 iq:
   name: nxiq
   hostname: iq-server.demo


### PR DESCRIPTION
#### Description of Change
Added initContainer option to change file ownerships to new UID's, when upgrading from previous IQ versions (with uid 997).

#### Things to Do Before Submitting
* Have you signed the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)?
* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
Yes. 
$ helm unittest -3 -t junit -o test-output.xml .

### Chart [ nexus-iq-server ] .

 PASS  deployment	tests/deployment_test.yaml
 PASS  ingress	tests/ingress_test.yaml
 PASS  persistentVolume	tests/pv_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       12 passed, 12 total
Snapshot:    0 passed, 0 total
Time:        38.641758ms

$ helm test iq
NAME: iq
LAST DEPLOYED: Fri Sep  9 09:12:53 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     iq-test-check-logs
Last Started:   Fri Sep  9 09:14:18 2022
Last Completed: Fri Sep  9 09:14:24 2022
Phase:          Succeeded
TEST SUITE:     iq-test-connection
Last Started:   Fri Sep  9 09:14:24 2022
Last Completed: Fri Sep  9 09:14:30 2022
Phase:          Succeeded

* Have you run `helm lint` on your change?
nexus-iq srini$ helm lint
==> Linting .

1 chart(s) linted, 0 chart(s) failed