### PR TITLE
INT-7315 Adding recent version of Alpine Helm 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 #
 
-FROM docker-all.repo.sonatype.com/alpine/helm:3.9.4
+FROM docker-all.repo.sonatype.com/alpine/helm:3.10.0
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh


### PR DESCRIPTION
#### Description of Change
Adding Helm version 3.10.0 to Docker file in order to check Helm Charts compatibility.

#### JIRA
https://issues.sonatype.org/browse/INT-7315

#### BUILD
https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-7315_Helm_charts_compatibility_Helm3.10.0/3/