### PR TITLE
Fixing link that doesn't render on Github Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,4 +31,4 @@ command with the `-f` option.
 
 ### Source
 
-Visit https://github.com/sonatype/helm3-charts.
+See the [`sonatype/helm3-charts`](https://github.com/sonatype/helm3-charts) repo.


### PR DESCRIPTION
The bare URL does not render as a hyperlink.

#### Description of Change

#### Things to Do Before Submitting

* Have you signed the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)?
* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change?
