### PR TITLE
Proof of Concept - Trigger release build

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -37,6 +37,12 @@ properties([
       name: 'chartVersion',
       description: '(Optional) Version of the Chart, like "139.0.0". If omitted, it will be calculated from the appVersion.',
     ),
+  ]),
+  pipelineTriggers([
+    triggers: [
+      upstream(upstreamProjects: 'insight/insight-brain/Release IQ Server',
+               threashold: hudson.model.Result.SUCCESS)
+    ]
   ])
 ])
 


### PR DESCRIPTION
A helm chart needs to be released after each IQ Server Release. This is the build which is run. 

Currently this build is triggered from the IQ Server post release [jenkinsfile](https://github.com/sonatype/insight-brain/blob/b755622905c507a15df688445788c855550dc45b/Jenkinsfile.postRelease#L73). 

```
stage('Publish IQ Server Helm Chart') {
      steps {
        build(
          job: 'integrations/cloud/Helm3 Charts/Main Release Build',
          parameters: [
            string(name: 'chart', value: 'nexus-iq-server'),
            string(name: 'appVersion', value: params.releaseVersion.replaceAll(/-.*/, '')),
          ]
        )
      }
    }
```

I would like to remove all integration triggers from the post release jenkins file and have the builds self contained.

1. Adds to the duration of the release unnecessarily. 
2. I don't want to get into the habit of adding builds to the post release jenkinsfile. (ideally just updating test/prod instances).
3. If anything goes wrong with this build, IQ devs won't know how to fix the issue. I think it's better to be contained in the integration space. 