### PR TITLE
Include nexus-iq-server-ha helm chart in to the release - CLM-23674

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -19,14 +19,13 @@ final jira = [
 
 final chartLocation = [
   'nexus-iq-server': 'nexus-iq',
-  'nexus-iq-server-ha': 'nexus-iq-ha',
   'nexus-repository-manager': 'nexus-repository-manager',
 ]
 
 properties([
   parameters([
     choice(
-      choices: ['', 'nexus-iq-server', 'nexus-iq-server-ha', 'nexus-repository-manager'],
+      choices: ['', 'nexus-iq-server', 'nexus-repository-manager'],
       name: 'chart',
       description: 'Chart to deploy.',
     ),
@@ -63,9 +62,6 @@ dockerizedBuildPipeline(
       runSafely "./upgrade.sh charts/nexus-iq ${chartVersion} ${params.appVersion}"
       runSafely './build-iq.sh'
       runSafely 'git add charts'
-    }
-
-    if ('nexus-iq-server-ha'.equals(params.chart)) {
       runSafely "curl -L 'https://github.com/sonatype/nexus-iq-server-ha/blob/main/docs/${nexusIqServerHaArtifactName}?raw=true' -o 'docs/${nexusIqServerHaArtifactName}'"
       runSafely './build-nexus.sh'
     }

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -19,13 +19,14 @@ final jira = [
 
 final chartLocation = [
   'nexus-iq-server': 'nexus-iq',
+  'nexus-iq-server-ha': 'nexus-iq-ha',
   'nexus-repository-manager': 'nexus-repository-manager',
 ]
 
 properties([
   parameters([
     choice(
-      choices: ['', 'nexus-iq-server', 'nexus-repository-manager'],
+      choices: ['', 'nexus-iq-server', 'nexus-iq-server-ha', 'nexus-repository-manager'],
       name: 'chart',
       description: 'Chart to deploy.',
     ),
@@ -43,6 +44,7 @@ properties([
 final chartVersion = calculateChartVersion(params.chartVersion, params.appVersion)
 final nexusRepoManagerArtifactName = "nexus-repository-manager-${chartVersion}.tgz"
 final awsResiliencyArtifactName = "nxrm-aws-resiliency-${chartVersion}.tgz"
+final nexusIqServerHaArtifactName = "nexus-iq-server-ha-${chartVersion}.tgz"
 
 dockerizedBuildPipeline(
   prepare: {
@@ -61,6 +63,11 @@ dockerizedBuildPipeline(
       runSafely "./upgrade.sh charts/nexus-iq ${chartVersion} ${params.appVersion}"
       runSafely './build-iq.sh'
       runSafely 'git add charts'
+    }
+
+    if ('nexus-iq-server-ha'.equals(params.chart)) {
+      runSafely "curl -L 'https://github.com/sonatype/nexus-iq-server-ha/blob/main/docs/${nexusIqServerHaArtifactName}?raw=true' -o 'docs/${nexusIqServerHaArtifactName}'"
+      runSafely './build-nexus.sh'
     }
 
     if ('nexus-repository-manager'.equals(params.chart)) {

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -59,11 +59,10 @@ dockerizedBuildPipeline(
     sonatypeZionGitConfig()
     runSafely "git checkout ${gitBranch(env)}"
     if ('nexus-iq-server'.equals(params.chart)) {
+      runSafely "curl -L 'https://github.com/sonatype/nexus-iq-server-ha/blob/main/docs/${nexusIqServerHaArtifactName}?raw=true' -o 'docs/${nexusIqServerHaArtifactName}'"
       runSafely "./upgrade.sh charts/nexus-iq ${chartVersion} ${params.appVersion}"
       runSafely './build-iq.sh'
       runSafely 'git add charts'
-      runSafely "curl -L 'https://github.com/sonatype/nexus-iq-server-ha/blob/main/docs/${nexusIqServerHaArtifactName}?raw=true' -o 'docs/${nexusIqServerHaArtifactName}'"
-      runSafely './build-nexus.sh'
     }
 
     if ('nexus-repository-manager'.equals(params.chart)) {


### PR DESCRIPTION
#### Description of Change

This includes the new nexus-iq-server-HA helm chart in to the chart release cycle. The chart is currently hosted/maintained in https://github.com/sonatype/nexus-iq-server-ha/tree/main/chart. 

**NOTE:**
The repository above is still not public (we will be making it public along with the official HA release). So until then, plan is to keep this PR as a DRAFT (not to publish the chart yet to artifacthub)
