### PR TITLE
Pin unittest plugin version to 0.2.11

### DIFF
--- a/build-iq.sh
+++ b/build-iq.sh
@@ -12,7 +12,7 @@
 # See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 #
 
-helm plugin install https://github.com/quintush/helm-unittest
+helm plugin install --version "0.2.11" https://github.com/quintush/helm-unittest
 
 set -e
 


### PR DESCRIPTION
#### Description of Change
-3 flag was removed in the latest version of the unittest plugin which is breaking builds in test stage. Simply removing the flag `-3` caused some tests to fail. Pinning the plugin version seems to make the build green: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/fix-build-use-fixed-version-unittest-plugin/

I did run `helm lint` on my branch however it was not successful:

```
> helm lint
==> Linting .
Error unable to check Chart.yaml file in chart: stat Chart.yaml: no such file or directory

Error: 1 chart(s) linted, 1 chart(s) failed
```

#### Things to Do Before Submitting

* Have you signed the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)?
* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change?
