### PR TITLE
update path for nexus repo ha helm chart

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -43,8 +43,7 @@ properties([
 final chartVersion = calculateChartVersion(params.chartVersion, params.appVersion)
 final nexusRepoManagerArtifactName = "nexus-repository-manager-${chartVersion}.tgz"
 final awsResiliencyArtifactName = "nxrm-aws-resiliency-${chartVersion}.tgz"
-final awsHaArtifactName = "nxrm-ha-aws-${chartVersion}.tgz"
-final azureHaArtifactName = "nxrm-ha-azure-${chartVersion}.tgz"
+final haArtifactName = "nxrm-ha-${chartVersion}.tgz"
 final nexusIqServerHaArtifactName = "nexus-iq-server-ha-${chartVersion}.tgz"
 
 dockerizedBuildPipeline(
@@ -70,8 +69,7 @@ dockerizedBuildPipeline(
     if ('nexus-repository-manager'.equals(params.chart)) {
       runSafely "curl -L 'https://github.com/sonatype/nxrm3-helm-repository/blob/main/docs/${nexusRepoManagerArtifactName}?raw=true' -o 'docs/${nexusRepoManagerArtifactName}'"
       runSafely "curl -L 'https://github.com/sonatype/nxrm3-helm-repository/blob/main/docs/${awsResiliencyArtifactName}?raw=true' -o 'docs/${awsResiliencyArtifactName}'"
-      runSafely "curl -L 'https://github.com/sonatype/nxrm3-ha-repository/blob/main/docs/${awsHaArtifactName}?raw=true' -o 'docs/${awsHaArtifactName}'"
-      runSafely "curl -L 'https://github.com/sonatype/nxrm3-ha-repository/blob/main/docs/${azureHaArtifactName}?raw=true' -o 'docs/${azureHaArtifactName}'"
+      runSafely "curl -L 'https://github.com/sonatype/nxrm3-ha-repository/blob/main/docs/${haArtifactName}?raw=true' -o 'docs/${haArtifactName}'"
       runSafely './build-nexus.sh'
     }
   },


### PR DESCRIPTION
#### Description of Change
Update the path from which the nexus repo ha helm charts are grabbed from. This is in correlation with PR: https://github.com/sonatype/nxrm3-ha-repository/pull/21