### PR TITLE
CLM-28180 - Some cycloneDX json scanning can cause drastic growth in clm-server.log size

### DIFF
--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -248,6 +248,7 @@ configYaml:
       "org.eclipse.birt.report.engine.layout.pdf.font.FontConfigReader": WARN
       "org.eclipse.jetty": INFO
       "org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter": INFO   # WARNING: This reveals credentials at DEBUG level
+      "com.networknt.schema": OFF
       "com.sonatype.insight.audit":
         appenders:
           # All appenders set to console


### PR DESCRIPTION
#### Description of Change
A fix was provide for this helm version 3 chart following the same idea implemented in CLM-21412.