### PR TITLE
Add startup probe to iq server pod - CLM-26122

### DIFF
--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -79,6 +79,13 @@ spec:
             - name: admin
               containerPort: {{ .Values.iq.adminPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: admin
+              {{- if .Values.iq.startupProbe }}
+                {{- toYaml .Values.iq.startupProbe | nindent 12 }}
+              {{- end }}
           livenessProbe:
             httpGet:
               path: /ping

--- a/charts/nexus-iq/tests/deployment_test.yaml
+++ b/charts/nexus-iq/tests/deployment_test.yaml
@@ -66,6 +66,17 @@ tests:
               containerPort: 8071
               protocol: TCP
       - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /ping
+              port: admin
+            initialDelaySeconds: 30
+            failureThreshold: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe
           value:
             httpGet:

--- a/charts/nexus-iq/tests/deployment_test.yaml
+++ b/charts/nexus-iq/tests/deployment_test.yaml
@@ -72,7 +72,7 @@ tests:
               path: /ping
               port: admin
             initialDelaySeconds: 30
-            failureThreshold: 30
+            failureThreshold: 180
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -57,6 +57,13 @@ iq:
 #    - name: JAVA_OPTS
 #      value: "-Djavax.net.ssl.keyStoreType=jks -Djavax.net.ssl.keyStore=/etc/secret-volume/keystore.jks -Djavax.net.ssl.keyStorePassword=$(KEYSTORE_PASSWORD) -Djavax.net.ssl.trustStoreType=jks -Djavax.net.ssl.trustStore=/etc/secret-volume/truststore.jks -Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD) -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs"
 
+  # Configures the startup probe for IQ pod
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 2
+    successThreshold: 1
   # Configures the liveness probe for IQ pod
   livenessProbe:
     initialDelaySeconds: 10

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -61,7 +61,7 @@ iq:
   startupProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
-    failureThreshold: 30
+    failureThreshold: 180
     timeoutSeconds: 2
     successThreshold: 1
   # Configures the liveness probe for IQ pod


### PR DESCRIPTION
#### Description of Change
Add startup probe to iq server pod

#### Things to Do Before Submitting

* Have you signed the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)?  :white_check_mark: 
* Have you added and run automated tests for your change?   :white_check_mark: 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change? :white_check_mark: 
