### PR TITLE
License as existingSecret (e.g. from extraManifests using SealedSecrets)

### DIFF
--- a/charts/nexus-iq/templates/_helpers.tpl
+++ b/charts/nexus-iq/templates/_helpers.tpl
@@ -6,6 +6,19 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "extra.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/nexus-iq/templates/deployment.yaml
+++ b/charts/nexus-iq/templates/deployment.yaml
@@ -131,11 +131,16 @@ spec:
             items:
               - key: config.yml
                 path: config.yml
-  {{- if .Values.iq.licenseSecret }}
+        {{- if or .Values.iq.license.secret .Values.iq.license.existingSecret }}
         - name: license-volume
           secret:
+          {{- if .Values.iq.license.secret }}
             secretName: {{ template "iqserver.fullname" . }}-license
-  {{- end }}
+          {{- end }}
+          {{- if .Values.iq.license.existingSecret }}
+            secretName: {{ .Values.iq.license.existingSecret }}
+          {{- end }}  
+        {{- end }}
   {{- if and (.Values.iq.secretName) (.Values.iq.secretMountName) }}
         - name: secret-volume
           secret:

--- a/charts/nexus-iq/templates/extraManifests.yaml
+++ b/charts/nexus-iq/templates/extraManifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ include "extra.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/nexus-iq/templates/licenseSecret.yaml
+++ b/charts/nexus-iq/templates/licenseSecret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.iq.licenseSecret }}
+{{- if .Values.iq.license.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "iqserver.fullname" . }}-license
 data:
-  license_lic: {{ .Values.iq.licenseSecret }}
+  license_lic: {{ .Values.iq.license.secret }}
 {{- end }}

--- a/charts/nexus-iq/values.yaml
+++ b/charts/nexus-iq/values.yaml
@@ -31,8 +31,18 @@ iq:
   hostname: iq-server.demo
   applicationPort: 8070
   adminPort: 8071
-  # base 64 encoded license file with no line breaks
-  licenseSecret: ""
+  license:
+    # base 64 encoded license file with no line breaks
+    secret: ""
+    # use existingSecret as reference for the license
+    # make sure the key is 'license_lic' and is cleartext
+    # apiVersion: v1
+    # kind: Secret
+    # metadata:
+    #   name: <name of existingSecret>
+    # stringData:
+    #  license_lic: ""
+    existingSecret: ""
   # add this line with this file path and the `licenseSecret` above to autoconfigure licensing
   # licenseFile: /etc/nexus-iq-license/license_lic
   extraLabels:
@@ -295,3 +305,5 @@ configYaml:
         currentLogFilename: /var/log/nexus-iq-server/clm-server.log
         archivedLogFilenamePattern: /var/log/nexus-iq-server/clm-server-%d.log.gz
         archivedFileCount: 50
+
+extraManifests: []


### PR DESCRIPTION
#### Description of Change
* Helm Chart has been extended to include the option of using an existing secret as a license reference.
* In order to generate this existing secret if required (e.g. encrypted as SealedSecret), the Helm Chart has also been supplemented with a list of 'extraManifests'

#### Things to Do Before Submitting

* Have you added and run automated tests for your change? not added but ran the existing test
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change? yes

#### Referencing Issues:
#33 