### PR TITLE
Switching from using rsc to sonatype cloud nxrm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 #
 
-FROM docker-all.repo.sonatype.com/alpine/helm:3.10.2
+FROM sonatype.repo.sonatype.app/docker-all/alpine/helm:3.10.2
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh


### PR DESCRIPTION
#### Description of Change
We now need to use sonatype.repo.sonatype.app/docker-all instead of RSC
#### Things to Do Before Submitting

* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change?
