### PR TITLE
Update Jira credential ID in Jenkinsfile-Release

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -14,7 +14,7 @@
 
 final jira = [
     versionPrefix: '', project: 'CLM', projectId: '10002',
-    credentialId : 'atlassian-jenkins', autoRelease: true, failOnError: true
+    credentialId : 'atlassian-jenkins-svc', autoRelease: true, failOnError: true
 ]
 
 final chartLocation = [


### PR DESCRIPTION
## Summary
- Migrate Jira credential from `atlassian-jenkins` to `atlassian-jenkins-svc` (service account Bearer token)

## Context
The `atlassian-jenkins` credential (tied to an individual employee account) is being decommissioned. All pipelines must use `atlassian-jenkins-svc` which uses the Atlassian API gateway with scoped Bearer token auth.

See: https://sonatype.atlassian.net/wiki/x/FADvi


## Test plan
- [x] Verify `atlassian-jenkins-svc` credential exists in Jenkins
- [ ] Confirm `jenkins-shared` PR #416 is merged (updates `jiraSetFixVersion` to Bearer auth)
- [ ] Next release pipeline run validates end-to-end

#### Description of Change

#### Things to Do Before Submitting

* Have you added and run automated tests for your change? 
  (See the [README](https://github.com/sonatype/helm3-charts/blob/main/README.md))
* Have you run `helm lint` on your change?
